### PR TITLE
docs(msg): 8-dim READMEs for common/sql/client/api-* sub-modules

### DIFF
--- a/kudos-ms/kudos-ms-msg/README.md
+++ b/kudos-ms/kudos-ms-msg/README.md
@@ -1,7 +1,7 @@
 # kudos-ms-msg
 
 **定位**：**消息（`msg`）原子服务**的 Gradle 聚合模块——承载消息模板、消息实例、消息发送、
-消息接收、接收组等领域能力。是平台级"系统通知 / 推送"的统一出口。
+消息接收、接收组等领域能力，是平台级"系统通知 / 推送"的统一出口。
 
 **在工程中的角色**：`SysConsts.ATOMIC_SERVICE_NAME = "msg"`；管理端 HTTP + 服务间 Feign。
 
@@ -9,73 +9,115 @@
 
 ## 子模块文档索引
 
-| 子模块 | 说明 |
-|--------|------|
-| [kudos-ms-msg-common](kudos-ms-msg-common/README.md) | 跨模块共享契约 |
-| kudos-ms-msg-sql | Flyway 迁移脚本 |
-| kudos-ms-msg-core | DAO / Service / 缓存 / API 实现 |
-| kudos-ms-msg-api-admin | 管理端 REST 控制器 |
-| kudos-ms-msg-api-public | 对外 Web 启动入口 |
-| kudos-ms-msg-api-internal | 对内 Provider 启动入口 |
-| kudos-ms-msg-client | Feign 代理 + 降级 |
+| 子模块 | 形态 | 一句话 |
+|--------|------|--------|
+| [kudos-ms-msg-common](kudos-ms-msg-common/README.md) | 契约库 | 4 个 `IMsg*Api` + 状态机枚举 + VO；`spring-web` 只 compileOnly |
+| [kudos-ms-msg-sql](kudos-ms-msg-sql/README.md) | 资源（纯 SQL） | Flyway 迁移，**当前只有 h2 方言** |
+| [kudos-ms-msg-core](kudos-ms-msg-core/README.md) | 业务实现库 | DAO / Service / 模板渲染 / 接收状态机 / 投递通道 listener |
+| [kudos-ms-msg-client](kudos-ms-msg-client/README.md) | Feign 客户端库 | 4 对 Proxy + Fallback，**不依赖 core** |
+| [kudos-ms-msg-api-admin](kudos-ms-msg-api-admin/README.md) | 管理端 controller 库 | `/api/admin/msg/...` 路由，5 个 BaseCrudController + 1 个手写 |
+| [kudos-ms-msg-api-public](kudos-ms-msg-api-public/README.md) | 启动入口 | 对外 Web 进程 |
+| [kudos-ms-msg-api-internal](kudos-ms-msg-api-internal/README.md) | 启动入口 | 对内 Feign Provider 进程，独有 Nacos / interservice-cache 依赖 |
 
 ---
 
-## 依赖关系（概念）
+## 依赖关系（实际）
 
 ```
                     ┌──────────────────┐
-                    │ kudos-ms-msg-    │
-                    │ common           │
+                    │ msg-common       │ ── compileOnly spring-web
                     └────────┬─────────┘
                              │
          ┌───────────────────┼───────────────────┐
          ▼                   ▼                   │
 ┌─────────────────┐  ┌─────────────────┐         │
-│ kudos-ms-msg-   │  │ kudos-ms-msg-   │         │
-│ sql             │  │ client          │         │
-└────────┬────────┘  └────────┬────────┘         │
-         │                    │ only common      │
-         └──────────┬─────────┘                  │
-                    ▼                            │
-            ┌───────────────┐                    │
-            │ kudos-ms-msg- │                    │
-            │ core          │◄───────────────────┘
+│ msg-sql         │  │ msg-client      │         │
+│ (Flyway 资源)   │  │ Proxy+Fallback  │         │
+└────────┬────────┘  └─────────────────┘         │
+         │                                       │
+         └──────────┬────────────────────────────┘
+                    ▼
+            ┌───────────────┐
+            │ msg-core      │
+            │ Service+DAO   │
             └───────┬───────┘
                     │
-    ┌───────────────┼───────────────┐
-    ▼               ▼               ▼
-┌────────┐   ┌────────────┐   ┌────────────┐
-│ api-   │   │ api-       │   │ api-       │
-│ admin  │   │ public     │   │ internal   │
-└────────┘   └────────────┘   └────────────┘
+    ┌───────────────┼─────────────────────────┐
+    ▼               ▼                         ▼
+┌──────────┐   ┌──────────┐               ┌──────────────┐
+│ api-     │   │ api-     │               │ api-internal │
+│ admin    │   │ public   │               │ +nacos       │
+│ (库)     │   │ (启动)   │               │ +interservice│
+└──────────┘   └──────────┘               └──────────────┘
 ```
+
+> ⚠️ **api-public / api-internal 并不 import api-admin**——三个 api-* 模块各自独立依赖
+> `msg-core`，互不交叉。这意味着 api-public 进程上**没有** admin controller 注册
+> （除非补依赖）。详见 `kudos-ms-msg-api-public/README.md` 的"已知限制"。
 
 ---
 
 ## 关键概念
 
-- **消息模板（`MsgTemplate`）**：参数化的消息蓝本，业务侧按模板 id + 参数发送
-- **消息实例（`MsgInstance`）**：模板渲染后的具体消息记录
-- **消息发送（`MsgSend`）**：调度 / 投递的状态机
-- **消息接收（`MsgReceive`）**：单一接收者的投递记录（含已读 / 未读 / 失败状态）
-- **接收组（`MsgReceiverGroup`）**：消息接收者的逻辑分组，避免一次性挑用户
-- **MsgUnreceived**：失败 / 未送达跟踪表（最近补的 feature batch 4）
+- **消息模板（`MsgTemplate`）**：参数化的消息蓝本，业务侧按 (tenantId, eventType, msgType, locale)
+  4 元组查询，按模板 + params 发送
+- **消息实例（`MsgInstance`）**：模板渲染后的具体消息记录（title + content + paramsUsed）
+- **消息发送（`MsgSend`）**：调度 / 投递的状态机；一次 publish 一条 send 记录
+- **消息接收（`MsgReceive`）**：单一接收者的投递记录（含 RECEIVED / UNREAD / READ / DELETED 状态）
+- **接收组（`MsgReceiverGroup`）**：消息接收者的逻辑分组（按部门 / 角色 / tag / 在线状态等
+  11 种 type），避免一次性穷举用户
+- **未送达（`MsgUnreceived`）**：失败 / 未送达跟踪表，含 retry_count / resolved 字段
 
 ## 业务流程
 
 ```
-template (蓝本) + params
-        ↓ 渲染
-instance (实例)
-        ↓ 调度
-send (按 receiver 拆分)
-        ↓ 投递
-receive (一对一记录) → MsgUnreceived (失败补偿)
+business code
+       ↓
+IMsgSendApi.publish(MsgPublishRequest)         ── tenantId + eventType + msgType + locale
+       ↓ Publish service
+template lookup → 渲染 → 落 msg_instance        ── MsgTemplateRenderer
+       ↓
+落 msg_send（status=PENDING）→ 投 MQ
+       ↓                          ↓ MQ 失败
+status=SENT_TO_MQ              status=FAILED_TO_SEND_TO_MQ
+       ↓ consumer 拉到
+status=CONSUMED_FROM_MQ
+       ↓ 各 channel listener（email / sms / siteMsg）发布
+拆分到每个 receiverId → 落 msg_receive
+       ↓ 投递失败
+                              → 落 msg_unreceived (含 reason)
+       ↓
+最终 status = SUCCESS / SUCCESS_PARTIAL / FAILED_FINAL
 ```
 
 ## 与其他服务的依赖
 
-- 调 `kudos-ms-user-client` 把 receiver-id 列表换成具体用户（邮箱 / 手机号 / 推送 token）
-- 调 `kudos-ability-comm-email` / `comm-sms-*` 走具体投递通道
-- 失败入 `MsgUnreceived` 表 + 通过 `kudos-ability-log-audit-mq` 异步审计
+- **`kudos-ms-user-core`**：`msg-core` 直接依赖（不是通过 Feign）——把 receiverId 换成
+  具体联系方式（邮箱 / 手机号 / 推送 token）
+- **`kudos-ability-comm-email`**：SMTP 投递通道（`MsgEmailDispatchListener`）
+- **`kudos-ability-comm-sms-aws`**：AWS SNS SMS 投递通道（msg-core README 提及）
+- **`kudos-ability-distributed-notify-common`**：channel listener 的事件分发抽象
+  （`@EventListener` 接收 `MsgDispatchEvent`）
+
+## 跨模块约定
+
+- **字典码 = 枚举耦合**：`send_status` / `receive_status` / `publish_method` 等字典项
+  的 `item_code` 必须等于 Kotlin 枚举的 `dictCode`。改动需要同步 `V1.0.0.2__insert_sys_dict_item.sql`
+  与对应 enum 类
+- **路径前缀约定**：管理端走 `/api/admin/msg/...`，服务间走 `/api/internal/msg/...`；
+  internal 路径直接挂在 common 的 `IMsg*Api` 方法注解上，让 Feign proxy 与服务端
+  controller 共享路径定义
+- **VO 命名链**：`{Domain}{Row / Detail / Edit / FormCreate / FormUpdate / Query}`，
+  全部放在 common 的对应业务子包 `vo/request|response/`
+
+## 整体已知限制
+
+详见各子模块 README。综合性问题：
+
+- ❗ **api-public 没有 admin 依赖**——三个 api-* 各自独立 boot，但 README 与 gradle
+  config 不一致，需要决定是补依赖还是改文档
+- ❗ **`IMsgReceiverGroupApi` 接口体空**——common / client / api-internal 三处都缺
+  接收组的跨服务读写
+- ❗ **SQL 只有 h2 方言**——生产 mysql / pg 移植尚未做；msg_template 索引也缺
+- ❗ **fallback 不区分 4xx / 5xx**——调用方拿到 null 时分不清是参数错还是对端挂
+- ❗ **错误码全是 `UNSPECIFIED`** —— 4 个 ErrorCodeEnum 占位待填

--- a/kudos-ms/kudos-ms-msg/kudos-ms-msg-api-admin/README.md
+++ b/kudos-ms/kudos-ms-msg/kudos-ms-msg-api-admin/README.md
@@ -1,18 +1,144 @@
 # kudos-ms-msg-api-admin
 
-Msg 服务的**管理端 REST 控制器层**。路径 `/api/admin/msg/...`。
+Msg 服务的 **管理端 REST 控制器层**——路径前缀 `/api/admin/msg/...`，面向运营 / 控制台
+界面。控制器调 `msg-core` 的 `IMsg*Service`，**不直接接触 DAO**。
 
-## 内容
+> 注：本模块 **既能作为库被嵌入** `msg-api-public` / `msg-api-internal`，也带有自己的
+> `MsgApiAdminApplication`（`@EnableKudos` + `main`）可单独 boot 起来调试，但**生产
+> 部署不走这个入口**——靠 public / internal 启动并通过 `@ComponentScan` 把 admin 的
+> controller 拉进来。
 
-- `*Controller` 类——一个领域（template / instance / send / receive / receiver-group）一个 controller
-- 控制器调用 `msg-core` 的 `IMsg*Service`，不直接接触 DAO
-- 返回类型直接用 `msg-common` 的 VO
+## 控制器清单
+
+| Controller | 路径前缀 | 委托 service | 模式 |
+|------------|----------|--------------|------|
+| `MsgTemplateAdminController` | `/api/admin/msg/template` | `IMsgTemplateService` | `BaseCrudController` |
+| `MsgInstanceAdminController` | `/api/admin/msg/instance` | `IMsgInstanceService` | `BaseCrudController` |
+| `MsgSendAdminController` | `/api/admin/msg/send` | `IMsgSendService` | `BaseCrudController` |
+| `MsgReceiveAdminController` | `/api/admin/msg/receive` | `IMsgReceiveService` | `BaseCrudController` |
+| `MsgReceiverGroupAdminController` | `/api/admin/msg/receiverGroup` | `IMsgReceiverGroupService` | `BaseCrudController` |
+| `MsgUnreceivedAdminController` | `/api/admin/msg/unreceived` | `IMsgUnreceivedService` | **手写**（非 CRUD） |
+
+### BaseCrudController 路由（标准 9 件套）
+
+5 个 controller 继承 `BaseCrudController<ID, Service, Query, Row, Detail, Edit, FormCreate, FormUpdate>`，
+自动暴露：
+
+```
+POST   /pagingSearch               → PagingSearchResult<Row>
+GET    /getDetail                  → Detail
+GET    /getEdit                    → Edit
+GET    /getCreateValidationRule    → Map<String, ValidationRule>
+GET    /getUpdateValidationRule    → Map<String, ValidationRule>
+POST   /save                       → ID
+PUT    /update                     → Boolean
+DELETE /delete                     → Boolean
+POST   /batchDelete                → Boolean
+```
+
+例：
+
+```kotlin
+@RestController
+@RequestMapping("/api/admin/msg/send")
+class MsgSendAdminController :
+    BaseCrudController<String, IMsgSendService, MsgSendQuery,
+                       MsgSendRow, MsgSendDetail, MsgSendEdit,
+                       MsgSendFormCreate, MsgSendFormUpdate>()
+```
+
+——一行 class 声明 = 9 个 endpoint。VO 类型链 `Row / Detail / Edit / FormCreate / FormUpdate`
+全来自 `msg-common`。
+
+### MsgUnreceivedAdminController（特例）
+
+故意不继承 `BaseCrudController`，因为 `msg_unreceived` 表是 **listener 驱动写入**
+（投递失败时由 channel listener 落表），admin 端没有"手工新增一条失败记录"的合理场景。
+只暴露三个运营操作：
+
+| 方法 | 路径 | 入参 | 返回 |
+|------|------|------|------|
+| `listUnresolvedBySend` | `GET /api/admin/msg/unreceived/listUnresolvedBySend` | `@RequestParam sendId` | `List<MsgUnreceivedRow>` |
+| `resolve` | `POST /api/admin/msg/unreceived/resolve` | `@RequestParam id` | `Boolean` |
+| `bumpRetry` | `POST /api/admin/msg/unreceived/bumpRetry` | `@RequestParam id` | `Boolean` |
+
+> ⚠️ `bumpRetry` **只累加计数 / 推进时间戳，不实际重发**——业务侧需要自己重新调
+> `IMsgSendApi.publish`，再回调 `bumpRetry` 记账。这是 README of `MsgUnreceivedAdminController`
+> 中显式说明的设计取舍。
+
+## 装配
+
+`MsgApiAdminAutoConfiguration`：
+
+```kotlin
+@Configuration
+@ComponentScan(basePackages = ["io.kudos.ms.msg.api.admin"])
+open class MsgApiAdminAutoConfiguration : IComponentInitializer {
+    override fun getComponentName() = "kudos-ms-msg-api-admin"
+}
+```
+
+通过 `IComponentInitializer` SPI（被 `ComponentInitializationDispatcher` 在 boot 时
+统一拉起）暴露给框架。**不是** Spring Boot 标准的 `AutoConfiguration.imports` 机制——
+kudos 自带的 dispatcher 替代了 Spring Boot 的 auto-config SPI，新增 controller 包不
+需要改 imports 文件，只要被 `@ComponentScan` 覆盖即可。
 
 ## 依赖
 
-- `kudos-ms-msg-core`
-- `kudos-ability-web-springmvc`
+```
+api(project(":kudos-ms:kudos-ms-msg:kudos-ms-msg-core"))
+api(project(":kudos-ability:kudos-ability-web:kudos-ability-web-springmvc"))
+testImplementation(project(":kudos-test:kudos-test-container"))
+```
 
-## 部署形态
+仅 core + web-springmvc——没有任何 distributed / cache / discovery 依赖；这些都是
+public / internal 启动模块的职责，让 admin 保持纯 controller 层。
 
-不是应用启动模块——启动入口在 `msg-api-public` / `msg-api-internal`。
+## 与 api-public / api-internal 的边界
+
+```
+                ┌──────────────────────┐
+                │ msg-api-public       │  ← 启动入口（管理端 HTTP / 用户面向）
+                │ MsgApiWebApplication │
+                └──────────┬───────────┘
+                           │ @ComponentScan 拉取
+                ┌──────────▼───────────┐
+                │ msg-api-admin        │  ← 本模块（库形态嵌入）
+                │ /api/admin/msg/...   │
+                └──────────────────────┘
+
+                ┌──────────────────────┐
+                │ msg-api-internal     │  ← 启动入口（服务间 Feign provider）
+                │ MsgApiProviderApp    │
+                └──────────┬───────────┘
+                           │ @ComponentScan 拉取（路径不同：internal/...）
+                           ▼
+                ┌──────────────────────┐
+                │ msg-api-internal     │
+                │ /api/internal/msg/...│ ← 不复用 admin，独立一套 thin facade
+                └──────────────────────┘
+```
+
+注意：**api-public 嵌入 admin**，所以 admin 的 `/api/admin/msg/...` 路由在 public
+进程上可见；**api-internal 不嵌入 admin**，它有自己的 `/api/internal/msg/...` 控制器
+直接实现 `IMsg*Api`。也就是说同一个 controller 不会同时挂两套路径——admin 与 internal
+是平行而非分层关系。
+
+## 已知限制 / 后续工作
+
+- ❗ **无 `@PreAuthorize`**：admin 控制器靠网关 / `EnableKudos` 框架级过滤器做访问控制；
+  漏配置或绕过网关时 `batchDelete` 等敏感 endpoint 直接暴露。建议至少在
+  `MsgTemplateAdminController.delete` / `batchDelete` / `MsgSendAdminController.save`
+  上加 method-level 鉴权
+- ❗ **路由由 `BaseCrudController` 反射生成**——没有显式 enum 路由列表，IDE 跳转 +
+  OpenAPI 生成都依赖反射 introspection，外部接入文档难写
+- ❗ **错误响应靠全局 handler**——controller 不显式声明 `@ResponseStatus` / problem+json，
+  错误结构由 `kudos-ability-web-springmvc` 兜底；前端如果想差异化处理，需要看全局
+  handler 的实现而非接口签名
+- ❗ **无 idempotency 头**：`POST /save` 重试时会创建多条记录；与 `msg-core` 的"重复
+  发送幂等性缺失"同源
+- ❗ **`MsgApiAdminApplication` 是误导**：模块里挂了 `main` 但生产不走这个入口；删除
+  + 让 admin 维持纯库形态会更清晰，避免误启
+- ❗ **`MsgUnreceivedAdminController.bumpRetry` 与 publish 解耦**——运营在 UI 上点
+  "重试"必须分两步（先重发再 bump），UX 容易漏；要么 admin 端封装一个 `retry` 接口
+  把 publish + bump 串起来

--- a/kudos-ms/kudos-ms-msg/kudos-ms-msg-api-internal/README.md
+++ b/kudos-ms/kudos-ms-msg/kudos-ms-msg-api-internal/README.md
@@ -1,23 +1,102 @@
 # kudos-ms-msg-api-internal
 
-Msg 服务**对内 Provider 进程**的启动入口与自动配置。
+Msg 服务 **对内 Provider 进程**的启动入口、自动配置与 `/api/internal/msg/...` 控制器。
+是 `msg-client` 中各 `IMsg*Proxy` 的对端实现——服务间 Feign 调用最终落到这里。
 
 ## 内容
 
-- `MsgApiProviderApplication` —— Spring Boot main
-- 与 api-public 对称，作为微服务间 Feign 调用的 provider 入口
+- `MsgApiProviderApplication` —— Spring Boot main，挂 `@EnableKudos`
+- `MsgApiProviderAutoConfiguration` —— `@ComponentScan("io.kudos.ms.msg.api.internal")` +
+  `IComponentInitializer.getComponentName() = "kudos-ms-msg-api-internal"`
+- 4 个 thin controller，每个 `implements IMsg*Api`（来自 common），方法体单行
+  转发到 core 的 `MsgXxxApi` 实现
 
-## 部署形态
+## 控制器清单
 
-- api-public：管理端 / 用户面向的 HTTP
-- api-internal：服务间 Feign 调用入口
+| Controller | 实现契约 | 委托对象（来自 msg-core） |
+|------------|----------|---------------------------|
+| `MsgSendInternalController` | `IMsgSendApi` | `MsgSendApi` |
+| `MsgTemplateInternalController` | `IMsgTemplateApi` | `MsgTemplateApi` |
+| `MsgReceiveInternalController` | `IMsgReceiveApi` | `MsgReceiveApi` |
+| `MsgInstanceInternalController` | `IMsgInstanceApi` | `MsgInstanceApi` |
 
-通过 yml 区分端口、actuator 暴露面、网络可见性。
+**没有 `IMsgReceiverGroupApi` 的控制器**——因为 common 里这个接口是空的（见 msg-common
+README "已知限制"）。
 
-## 依赖
+实现模式：
 
-同 api-public——core + api-admin + web 栈。
+```kotlin
+@RestController
+class MsgReceiveInternalController(
+    private val msgReceiveApi: MsgReceiveApi,
+) : IMsgReceiveApi {
 
-## 已知限制
+    override fun getReceivesByUserId(receiverId: String) =
+        msgReceiveApi.getReceivesByUserId(receiverId)
 
-- ❗ api-internal 与 api-public 的边界由 yml 决定，代码层未硬分隔
+    override fun markRead(id: String) =
+        msgReceiveApi.markRead(id)
+    // ...
+}
+```
+
+> ⚠️ controller 类**没有** `@RequestMapping("/api/internal/...")` —— 路径全部继承自
+> common 接口的方法级 `@GetMapping` / `@PostMapping`。看到 controller 想知道 URL 必须
+> 跳进 `IMsg*Api`；IDE 里 Spring inspect 可以 resolve 出来，但裸读代码会迷路。
+
+## 部署形态对比
+
+| 维度 | api-internal | api-public |
+|------|--------------|------------|
+| 路径前缀 | `/api/internal/msg/...` | `/api/admin/msg/...`（见已知限制） |
+| 受众 | 内部微服务（通过 Feign proxy） | 浏览器 / 控制台 |
+| 服务发现 | **必须注册到 Nacos** | 通常不强求 |
+| 配置中心 | Nacos config | 文件 / env |
+| 跨服务缓存 | `cache-interservice-provider` 暴露本服务缓存接口 | 无 |
+
+## 依赖（实际 `build.gradle.kts`）
+
+```
+api(":kudos-ms-msg-core")
+api(":kudos-ability-cache-interservice-provider")    ← 独有
+api(":kudos-ability-distributed-discovery-nacos")    ← 独有
+api(":kudos-ability-distributed-config-nacos")       ← 独有
+api(":kudos-ability-web-springmvc")
+```
+
+比 api-public 多出 **3 个分布式相关依赖**：
+- **`discovery-nacos`**：进程启动时往 Nacos 注册服务，msg-client 的 `@FeignClient(name = "msg-...")`
+  通过 Nacos 解析 IP
+- **`config-nacos`**：拉远端配置，让运维不用滚动重启就能改 yml
+- **`cache-interservice-provider`**：把 msg 服务的本地缓存暴露成跨服务可读，供其他服务
+  通过 `cache-interservice-consumer` 直接拿数据（不是 Feign 调用，更轻）
+
+## 装配链
+
+```
+MsgApiProviderApplication(@EnableKudos)
+  ↓ boot
+ComponentInitializationDispatcher 扫到所有 classpath 上的 IComponentInitializer：
+  - MsgAutoConfiguration                  (msg-core)
+  - MsgApiProviderAutoConfiguration       (本模块, scan io.kudos.ms.msg.api.internal)
+  - 各 ability 模块的 *AutoConfiguration   (cache / ktorm / nacos / springmvc / ...)
+  ↓
+四个 internal controller 被注册成 bean，分别绑定到 IMsg*Api 注解的路径
+```
+
+## 已知限制 / 后续工作
+
+- ❗ **api-internal 与 api-public 的边界由 yml 决定，代码层未硬分隔**——内部 controller
+  的路径前缀 `/api/internal/...` 是契约（来自 common 接口注解），如果运维把 internal
+  jar 部署到公网端口、没靠网关 ACL 拦截，外部就能直接调 `publish`。建议在 yml 里
+  配 servlet path-based filter 或加 spring-security 全局拦截
+- ❗ **缺 `IMsgReceiverGroupInternalController`**——等 common 的 `IMsgReceiverGroupApi`
+  补完方法后同步补
+- ❗ **rate limit / circuit breaker 全靠基础设施**——controller 层无任何 Resilience4j
+  / Sentinel 装配；远端 burst 流量直冲 core service，要靠 ability-distributed-* 兜底
+- ❗ **无 trace id propagation 显式装配**——指望 `@EnableKudos` 拉的 starter 处理；
+  排障时需要确认链路追踪 starter 实际在 classpath
+- ❗ **无 yml**——本模块零配置文件，nacos endpoint / serverPort / spring profile 都
+  靠运行环境注入。本地起进程必须先设 `NACOS_SERVER_ADDR` 等环境变量
+- ❗ **`MsgApiProviderApplication` 和 `MsgApiAdminApplication` 命名不一致**：
+  Web / Provider / Admin 三套命名混用；建议统一成 Web / Provider 或全部 Application

--- a/kudos-ms/kudos-ms-msg/kudos-ms-msg-api-public/README.md
+++ b/kudos-ms/kudos-ms-msg/kudos-ms-msg-api-public/README.md
@@ -1,11 +1,14 @@
 # kudos-ms-msg-api-public
 
-Msg 服务**对外 Web 进程**的启动入口与自动配置。
+Msg 服务 **对外 Web 进程**的启动入口与自动配置。生产部署 msg 的"公开 HTTP 面"（管理端 /
+用户控制台调用）就跑这个 jar。
 
 ## 内容
 
-- `MsgApiWebApplication` —— Spring Boot main
-- 装配 msg-core + msg-api-admin + 完整 web 栈
+- `MsgApiWebApplication` —— Spring Boot `main`，加 `@EnableKudos` 触发 kudos 框架
+  自动装配
+- `MsgApiWebAutoConfiguration` —— `@ComponentScan("io.kudos.ms.msg.api.public")` +
+  `IComponentInitializer.getComponentName() = "kudos-ms-msg-api-public"`
 
 ## 启动
 
@@ -13,12 +16,48 @@ Msg 服务**对外 Web 进程**的启动入口与自动配置。
 ./gradlew :kudos-ms:kudos-ms-msg:kudos-ms-msg-api-public:bootRun
 ```
 
-## 依赖
+## 依赖（实际 `build.gradle.kts`）
 
-- `kudos-ms-msg-api-admin`、`kudos-ms-msg-core`
-- `kudos-ability-web-springmvc`
+```
+api(project(":kudos-ms:kudos-ms-msg:kudos-ms-msg-core"))
+api(project(":kudos-ability:kudos-ability-web:kudos-ability-web-springmvc"))
+```
+
+只有 `msg-core` + `web-springmvc`。**没有** `msg-api-admin` / `msg-api-internal` 的依赖
+——所有控制器都不在 classpath 上。
 
 ## 与 api-internal 的区别
 
-api-public 面向最终用户 / 控制台；api-internal 面向服务间 Feign 调用。代码层基本一样，
-通过端口 / actuator 等 yml 配置进行实际分离。
+| 维度 | api-public | api-internal |
+|------|------------|--------------|
+| 启动类 | `MsgApiWebApplication` | `MsgApiProviderApplication` |
+| 包路径 | `io.kudos.ms.msg.api.public` | `io.kudos.ms.msg.api.internal` |
+| 路径规约 | `/api/admin/msg/...`（管理端） | `/api/internal/msg/...`（Feign provider） |
+| 额外依赖 | 无 | `discovery-nacos` / `config-nacos` / `cache-interservice-provider` |
+| 受众 | 浏览器 / 控制台 | 其他微服务（通过 msg-client 的 Feign proxy） |
+
+代码层差异极小——主要靠运行期 yml（端口 / actuator / 网络可见性）分离。所以同一份
+`msg-core` 业务实现在两个进程都跑一份。
+
+## 已知限制 / 后续工作
+
+- ❗ **`build.gradle.kts` 没有 `msg-api-admin` 依赖**，但 README 历来说"装配
+  msg-core + msg-api-admin + 完整 web 栈"——**配置与文档对不上**。两种解释：
+  (a) 漏配 admin 依赖，导致 public 进程实际上没有任何 `/api/admin/msg/...` 控制器
+  注册（boot 起来但没业务路由）；
+  (b) 设计意图就是把 admin 单独部署，public 只是 core + web 的 boot shell——但那样
+  又解释不通为什么会拉 `web-springmvc`。
+  **需要决定**：要么把 admin 加进依赖，要么把 README 改成"纯 core boot shell"并解释清楚
+- ❗ **缺 `application.yml`**——repo 内没有任何 `application*.yml` / `application*.properties`，
+  配置完全靠运行环境注入（容器 env、Spring Cloud Config）。CI 集成测试 / 本地调试
+  缺示例文件，需要先翻 sibling 服务的 yml 模板
+- ❗ **`MsgApiWebAutoConfiguration` `@ComponentScan` 只扫 `io.kudos.ms.msg.api.public`**
+  ——只能拉到本模块的 controller / 配置；其他模块（admin / internal）的 controller 即使
+  classpath 上有，也得靠各自的 `IComponentInitializer` 被框架 dispatcher 拉起。如果想
+  让 public 同时挂 admin 路由，需要在依赖里加 admin 模块（dispatcher 会自动拉 admin 的
+  `MsgApiAdminAutoConfiguration`）
+- ❗ **无 actuator / observability 显式装配**——靠 `@EnableKudos` 透传，具体暴露哪些
+  endpoint 看 yml；本模块代码层零控制
+- ❗ **安全过滤器链未配置**——controller 层无 `@PreAuthorize`，public 进程的鉴权完全
+  托管给外部网关；如果绕过网关直连本进程端口，所有 admin endpoint（前提是 admin 依赖
+  补上后）都是裸的

--- a/kudos-ms/kudos-ms-msg/kudos-ms-msg-client/README.md
+++ b/kudos-ms/kudos-ms-msg/kudos-ms-msg-client/README.md
@@ -1,11 +1,74 @@
 # kudos-ms-msg-client
 
 Msg 服务的 **Feign 客户端代理 + 降级**——其他微服务通过 Kotlin 接口调用远端 msg 服务。
+**不依赖 msg-core**，纯远端调用包装。
 
-## 内容
+## 包结构
 
-- `*Proxy : IMsg*Api` —— Feign 接口
-- `*Fallback` —— 调用失败时的降级（继承 `AbstractFeignFallbackSupport`）
+```
+io.kudos.ms.msg.client.
+├── template/   {proxy/IMsgTemplateProxy,  fallback/MsgTemplateFallback}
+├── instance/   {proxy/IMsgInstanceProxy,  fallback/MsgInstanceFallback}
+├── receiver/   {proxy/IMsgReceiveProxy,   fallback/MsgReceiveFallback}
+└── send/       {proxy/IMsgSendProxy,      fallback/MsgSendFallback}
+```
+
+每个业务领域一对 `Proxy + Fallback`，全部都是 Kotlin `interface` + `open class`，
+方便 Spring Cglib 代理。
+
+## Proxy 与 FeignClient name
+
+| Proxy | `@FeignClient(name)` | 实现的契约 | 降级 |
+|-------|----------------------|------------|------|
+| `IMsgTemplateProxy` | `"msg-template"` | `IMsgTemplateApi` | `MsgTemplateFallback` |
+| `IMsgInstanceProxy` | `"msg-instance"` | `IMsgInstanceApi` | `MsgInstanceFallback` |
+| `IMsgReceiveProxy` | `"msg-receive"` | `IMsgReceiveApi` | `MsgReceiveFallback` |
+| `IMsgSendProxy` | `"msg-send"` | `IMsgSendApi` | `MsgSendFallback` |
+
+> ⚠️ FeignClient name **按业务名而非服务名**：`msg-template` / `msg-send` 都指向同一个
+> `msg` 微服务实例（注册名 `msg`，见 `SysConsts.ATOMIC_SERVICE_NAME`）。Spring Cloud 的
+> 服务发现按 name 解析，这意味着 4 个 proxy 各持一份 LoadBalancer 状态。如果想做精细
+> 的熔断隔离（让 send 失败不影响 template 读取），这种拆法 OK；如果将来想合并，需要先
+> 检查 Hystrix / Resilience4j 的 instance metrics 是否有依赖。
+
+接口体常态：
+
+```kotlin
+@FeignClient(name = "msg-send", fallback = MsgSendFallback::class)
+interface IMsgSendProxy : IMsgSendApi
+```
+
+——`IMsgSendApi` 在 common 已经挂好方法级 `@PostMapping("/api/internal/msg/send/publish")`，
+Feign 直接复用，proxy 不需要再写路径。
+
+## Fallback 模式
+
+所有 fallback 都继承 `AbstractFeignFallbackSupport("ComponentName")`
+（来自 `kudos-ability-distributed-client-feign`）：
+
+- **读接口**调 `warnRead(method, args)` —— `WARN` 级别落日志 + 返回安全默认值（`null` /
+  `emptyList()` / `0` / `false`）
+- **写接口**调 `errorWrite(method, args)` —— `ERROR` 级别落日志 + 返回失败标识（`false` /
+  `0` / `null`）让调用方决定补偿
+
+实例：
+
+```kotlin
+@Component
+open class MsgSendFallback :
+    AbstractFeignFallbackSupport("MsgSendFallback"), IMsgSendProxy {
+
+    override fun publish(request: MsgPublishRequest): String? {
+        errorWrite("publish", request)
+        return null         // ← 调用方按 null 判定走重试或入业务侧补偿表
+    }
+}
+```
+
+**核心原则**：fallback **从不抛异常**——异常一旦冒出去，调用方业务流就断了。所有降级
+路径都返回"看似成功但内容为空 / null"，把决策权交还调用方。
+
+## 使用姿态
 
 业务侧引入：
 
@@ -17,12 +80,67 @@ implementation(project(":kudos-ms:kudos-ms-msg:kudos-ms-msg-client"))
 
 ```kotlin
 @Autowired private val msgSendProxy: IMsgSendProxy
-msgSendProxy.send(templateCode = "WELCOME", params = mapOf(...), receivers = ...)
+
+val sendId = msgSendProxy.publish(MsgPublishRequest(
+    tenantId = ...,
+    eventTypeDictCode = "user.welcome",
+    msgTypeDictCode = "system",
+    receiverIds = setOf(userId),
+    params = mapOf("nickname" to "K"),
+    publishMethod = "email",
+))
+if (sendId == null) {
+    // 远端不通 / 模板缺失 / 入参非法——业务侧自决重试 or 入补偿
+}
 ```
+
+业务侧 **必须 `@EnableFeignClients`** 扫到 `io.kudos.ms.msg.client.*` 包路径；当前
+client 模块**没有自带 auto-configuration**，靠消费方扫描注册。如果消费方用
+`@SpringBootApplication`（默认从启动类同包向下扫），需要保证启动类在 `io.kudos.*` 下，
+或者显式：
+
+```kotlin
+@EnableFeignClients(basePackages = ["io.kudos.ms.msg.client"])
+```
+
+## 与 common 的对齐
+
+- `IMsgReceiverGroupApi` 在 common 里**接口体为空**——client 这边对应位置**没有**
+  `IMsgReceiverGroupProxy` / Fallback。后续若 common 给 ReceiverGroupApi 加方法，
+  client 必须同步补 proxy + fallback，否则跨服务读 / 写接收组只能走 REST。
+- common 里 4 个 `IMsg*Api` 的方法签名变更需要立即同步到 client；编译器会替你检查
+  （proxy 实现了 common 接口），所以契约漂移会在编译期暴露——这是 `interface IMsgSendProxy : IMsgSendApi`
+  这种"继承式 proxy"的最大优点。
+
+## 测试
+
+仅一个标记类：`test-src/io/kudos/ms/msg/consumer/MsgConsumerMarkerTest.kt` 是
+`object MsgConsumerMarkerTest` —— 不是真实测试用例，作用是占住 `io.kudos.ms.msg.consumer`
+test classpath 包路径，给上层集成测试（在 consumer 域）注入测试上下文时做扫描定位用。
+**没有真实 unit test / integration test**——proxy 的有效性靠下游服务的端到端测试覆盖。
 
 ## 依赖
 
-- `kudos-ms-msg-common`
-- `kudos-ability-distributed-client-feign`
+- `api(project(":kudos-ms:kudos-ms-msg:kudos-ms-msg-common"))` —— 契约
+- `api(project(":kudos-ability:kudos-ability-distributed:kudos-ability-distributed-client:kudos-ability-distributed-client-feign"))`
+  —— Feign 抽象 + `AbstractFeignFallbackSupport` 基类 + 全局 RequestInterceptor / FallbackFactory
+- `testImplementation(project(":kudos-test:kudos-test-container"))`
 
-**不依赖 msg-core**——纯远端调用包装。
+无 `kudos-ms-msg-core` 依赖——避免循环，client 不能含任何业务实现。
+
+## 已知限制 / 后续工作
+
+- ❗ **无 auto-configuration**：业务侧必须自己 `@EnableFeignClients(basePackages = ...)`，
+  容易漏配——可考虑在 client 内放一个 `MsgClientAutoConfiguration` + `@EnableFeignClients`
+  + `META-INF/spring/...AutoConfiguration.imports` 让消费方零配置
+- ❗ **缺 `IMsgReceiverGroupProxy`**：等 common 里的 `IMsgReceiverGroupApi` 补完方法
+  即可补
+- ❗ **fallback 静默吃错原因**：`warnRead` / `errorWrite` 只记 method + args，没把
+  Feign 抛出的原始异常 / HTTP 状态码记上下文。生产排障要先看 `feign.client.config` 的
+  trace 才能定位
+- ❗ **没有针对 5xx vs 4xx 的差异化降级**：当前 4xx（业务校验失败）和 5xx（服务不可用）
+  都走同一条 fallback，调用方拿到 null 时分不清"我传错参数"还是"对方挂了"
+- ❗ **`@FeignClient(name = ...)` 用业务名而非服务名**——4 个 proxy 各自独立做负载均衡
+  与熔断；如果 ops 想观测 msg 服务整体调用，需要在 Grafana 上手动 sum 4 个 metric
+- ❗ **无真实测试**：marker test 不覆盖任何契约/降级行为；建议至少加一个 `WireMock`
+  驱动的契约测试，验证 proxy 拼出来的请求路径 / body 跟 common 接口注解一致

--- a/kudos-ms/kudos-ms-msg/kudos-ms-msg-common/README.md
+++ b/kudos-ms/kudos-ms-msg/kudos-ms-msg-common/README.md
@@ -1,14 +1,161 @@
 # kudos-ms-msg-common
 
-`msg` 原子服务共享契约层。包结构：**`io.kudos.ms.msg.common` 下先按业务模块再分 `api` / `consts` / `enums` / `vo`**；横切内容放在 **`platform`**（若存在）。
+`msg` 原子服务的**共享契约层**——所有跨进程契约（Feign API、错误码、VO、缓存条目）落在这里，
+core / client / api-* 三侧都靠它对齐。
 
-## 模块与 API
+**依赖姿态**（见 `build.gradle.kts`）：
+- `api(project(":kudos-base"))`
+- `compileOnly(platform(libs.spring.boot.bom))` + `compileOnly("org.springframework:spring-web")`
 
-| 模块包 | API（`*.api`） |
-|--------|----------------|
-| `send` | `IMsgSendApi` |
-| `instance` | `IMsgInstanceApi` |
-| `receiver` | `IMsgReceiveApi`、`IMsgReceiverGroupApi`（原 `receive` / `receivergroup` 合并为同一模块包） |
-| `template` | `IMsgTemplateApi` |
+`spring-web` 用 `compileOnly` ——只是为了在 `IMsg*Api` 上挂方法级 `@GetMapping` /
+`@PostMapping`，让 Feign 端识别路由；运行期不强制把 spring-web 拉进 client / consumer。
+与 sys-common / user-common / auth-common 同模式。
 
-路径示例：`io.kudos.ms.msg.common.send.api`、`io.kudos.ms.msg.common.receiver.api`、`io.kudos.ms.msg.common.template.vo`。
+## 包结构（先按业务再分 layer）
+
+```
+io.kudos.ms.msg.common.
+├── send/
+│   ├── api/                ── IMsgSendApi
+│   ├── enums/              ── MsgSendStatusEnum、MsgPublishMethodEnum、MsgSendErrorCodeEnum
+│   └── vo/
+│       ├── MsgDispatchEvent          (Spring ApplicationEvent payload，给 channel listener)
+│       ├── MsgSendCacheEntry
+│       ├── request/                  (MsgPublishRequest、MsgSendForm*、MsgSendQuery)
+│       └── response/                 (MsgSendRow / Edit / Detail)
+├── instance/
+│   ├── api/                ── IMsgInstanceApi
+│   ├── enums/              ── MsgInstanceErrorCodeEnum
+│   └── vo/                 ── MsgInstanceCacheEntry + request/response
+├── receiver/                          ← 注意是 receiver 不是 receive
+│   ├── api/                ── IMsgReceiveApi、IMsgReceiverGroupApi
+│   ├── enums/              ── MsgReceiveStatusEnum、MsgUnreceivedReasonEnum、
+│   │                          MsgReceive/ReceiverGroupErrorCodeEnum
+│   └── vo/                 ── MsgReceiveCacheEntry、MsgReceiverGroupCacheEntry + request/response
+└── template/
+    ├── api/                ── IMsgTemplateApi
+    ├── enums/              ── MsgTemplateErrorCodeEnum
+    └── vo/
+        ├── RenderedMessage           (渲染产物：title + content + paramsUsed)
+        ├── MsgTemplateCacheEntry
+        ├── request/                  (IMsgTemplateFormBase / Create / Update / Query)
+        └── response/                 (MsgTemplateRow / Edit / Detail)
+```
+
+旧的 `receive` / `receivergroup` 已合并到 **`receiver`** 单一业务包下，但 API 接口仍
+分成两个：`IMsgReceiveApi`（单条收件）与 `IMsgReceiverGroupApi`（接收组定义）。
+
+## Feign 路径约定
+
+所有对外 API 路径都走 `/api/internal/msg/{domain}/{op}`，并且：
+- **方法级注解**——`@GetMapping` / `@PostMapping` 直接挂在接口方法上
+- **接口本身不带 `@RequestMapping` 前缀**——Feign 通过完整路径解析，省一层拼接
+- 服务端控制器 `implements IMsg*Api`，自动继承同样的路径，**契约 = 路由**
+
+| 接口 | 方法 | 路径 |
+|------|------|------|
+| `IMsgSendApi` | `publish(MsgPublishRequest)` | `POST /api/internal/msg/send/publish` |
+| `IMsgTemplateApi` | `getTemplateById(id)` | `GET /api/internal/msg/template/getTemplateById` |
+| `IMsgTemplateApi` | `getTemplateByEvent(tenantId, eventType, msgType, locale?)` | `GET /api/internal/msg/template/getTemplateByEvent` |
+| `IMsgInstanceApi` | `getInstanceById(id)` | `GET /api/internal/msg/instance/getInstanceById` |
+| `IMsgReceiveApi` | `getReceivesByUserId(receiverId)` | `GET /api/internal/msg/receive/getReceivesByUserId` |
+| `IMsgReceiveApi` | `getUnreadCountByUserId(receiverId)` | `GET /api/internal/msg/receive/getUnreadCountByUserId` |
+| `IMsgReceiveApi` | `markRead(id)` | `POST /api/internal/msg/receive/markRead` |
+| `IMsgReceiveApi` | `markAllReadByUserId(receiverId)` | `POST /api/internal/msg/receive/markAllReadByUserId` |
+| `IMsgReceiverGroupApi` | （空） | —— |
+
+> ⚠️ `IMsgReceiverGroupApi` 当前**接口体为空**——CacheEntry / Form / Query 都准备好了，
+> 但没暴露任何方法。这意味着：(a) 跨服务暂时无法读取 / 创建接收组，admin 端只能通过
+> `MsgReceiverGroupAdminController` 走 `/api/admin/...`；(b) client 模块对应位置也
+> **没有 Proxy / Fallback**，调用方暂时不必担心 fallback 静默吃错误。后续补接口前先想清楚
+> "跨服务到底需要哪些操作"——只读 lookup 还是含写。
+
+## 状态机
+
+### MsgSendStatusEnum（`msg_send.send_status_dict_code`）
+
+```
+PENDING (00)
+   ↓ Publish service 投 MQ 成功
+SENT_TO_MQ (11) ─→ 投 MQ 失败时直接置 FAILED_TO_SEND_TO_MQ (21)
+   ↓ Consumer 拉到消息
+CONSUMED_FROM_MQ (31)
+   ↓ Consumer 完成发送
+SUCCESS (33) / SUCCESS_PARTIAL (32) / FAILED_FINAL (22)
+
+旁路：CANCELLED (01)  —— admin 主动止损
+```
+
+### MsgReceiveStatusEnum（`msg_receive.receive_status_dict_code`）
+
+```
+RECEIVED (11) ─┐
+               ├── 都算"未读"，并入 UNREAD_CODES = {11, 01}
+UNREAD (01) ───┘
+        ↓ 点开
+READ (12)
+        ↓ 收件箱删除（保留行做审计）
+DELETED (21)
+```
+
+> `RECEIVED` 与 `UNREAD` 的区别：`RECEIVED` 是落库初始态（接收方还没拉过），`UNREAD`
+> 是拉过但未点开。`getUnreadCountByUserId` 用 `UNREAD_CODES` 同时算两者。
+
+### MsgUnreceivedReasonEnum
+
+`NO_CONTACT` / `CHANNEL_REJECT` / `TIMEOUT` / `LISTENER_ERROR` / `EMPTY_RECEIVERS` /
+`UNKNOWN`——写入 `msg_unreceived.fail_reason` 前缀，便于运营按原因分桶处理。
+
+## 关键 VO
+
+- **`MsgPublishRequest`**：4-tuple lookup（`tenantId` + `eventTypeDictCode` +
+  `msgTypeDictCode` + `localeDictCode?`）+ `receiverIds` + `params` + `publishMethod`。
+  Publish 服务用前 4 个字段去 `getTemplateByEvent` 拿模板
+- **`MsgDispatchEvent`**：Spring `ApplicationEvent` payload，由 publish service 发布、
+  各 channel listener（email / sms / siteMsg）订阅。包含已渲染的 `renderedTitle` /
+  `renderedContent` —— **模板不再传**，避免 listener 重复渲染
+- **`RenderedMessage`**：渲染产物三元组（`title` / `content` / `paramsUsed`）。
+  `paramsUsed` 是审计字段——记录这次渲染实际替换了哪些占位符的值
+- **`MsgTemplateCacheEntry`**：含 `defaultActive` / `defaultTitle` / `defaultContent`——
+  渲染时若 `title.isBlank()` 回退到默认值，逻辑见 `MsgTemplateRenderer`
+- **`MsgReceiverGroupCacheEntry`**：含 `defineTable` + `nameColumn`，暗示按"动态表 + 取
+  哪一列做姓名"的方式解析组成员；解析逻辑在 core 而非 common
+
+## 错误码
+
+`MsgSendErrorCodeEnum` / `MsgTemplateErrorCodeEnum` / `MsgReceiveErrorCodeEnum` /
+`MsgReceiverGroupErrorCodeEnum`——**当前都只有 `UNSPECIFIED` 一项占位**。错误码体系
+是预留扩展点，新增前应先和 `kudos-base` 的 `IErrorCodeEnum` 约定的 code 段落不冲突。
+
+## 与其他模块的关系
+
+```
+                    base(kudos-base)
+                          ▲
+                          │ api
+                  ┌───────┴───────┐
+                  │ msg-common    │  ←—— compileOnly: spring-web (仅注解可见)
+                  └───────┬───────┘
+            ┌─────────────┼─────────────┐
+            ▼             ▼             ▼
+        msg-core      msg-client     msg-api-* (通过 core 间接拉)
+        (实现 IMsg*Api)  (Feign + Fallback)
+```
+
+common **不依赖任何运行时框架**——纯契约，能被任何 JVM 服务消费。这是为什么 spring-web
+要用 `compileOnly`：注解只在编译期看到，运行时由消费方决定要不要拉。
+
+## 已知限制 / 后续工作
+
+- ❗ **`IMsgReceiverGroupApi` 接口体为空**——业务侧暂无法跨服务取接收组定义，client
+  模块对应位置也缺 Proxy
+- ❗ **错误码体系全是 `UNSPECIFIED` 占位**——异常发生时调用方无法按 errorCode 做差异化
+  处理，只能看异常 message
+- ❗ **`MsgPublishMethodEnum` 缺 `all_user`**——SQL 字典里有这一项，枚举侧未覆盖；如果
+  publish 时传 `all_user` 会进 enum 匹配兜底分支
+- ❗ **DTO 缺校验注解**——`MsgPublishRequest`、`MsgTemplateFormCreate` 等都没挂
+  `@NotNull` / `@Size`；校验逻辑全在 core 侧手写，分散且易遗漏
+- ❗ **`MsgSendCacheEntry.jobId` 隐含批量调度概念**，但 common 里没有 Job 相关类型；
+  调度抽象目前在 core 内部，跨服务可见度为零
+- ❗ **VO 命名混用**：`MsgSendRow` vs `MsgInstanceRow` vs `MsgReceiveRow` 命名同模式 OK，
+  但 `MsgReceiverGroupDetail` 中含 `audit timestamps`，其他 Detail VO 不含——契约不齐

--- a/kudos-ms/kudos-ms-msg/kudos-ms-msg-core/README.md
+++ b/kudos-ms/kudos-ms-msg/kudos-ms-msg-core/README.md
@@ -75,8 +75,9 @@ UNREAD ── markRead ──► READ
   定时任务从 `msg_unreceived` 拉数据走 re-send 路径
 - ❗ **控制器无 `@PreAuthorize`**：admin 控制器靠网关 / 外部鉴权过滤器做访问控制；漏
   配置时 `bulkSend` 等敏感 endpoint 直接暴露
-- ❗ **模板内容大小无上限**：`msg_template.content` 通常是 TEXT 列；恶意大模板可导致
-  渲染 OOM。建议在 form 校验加 maxLength
+- ❗ **模板内容大小无上限**：`msg_template.content` 在 h2 是 `varchar`（无界，等价 CLOB），
+  跨方言移植到 mysql / pg 时也建议给上限；当前 form 校验未限 maxLength，恶意大模板可
+  导致渲染 OOM
 - ❗ **没有审计日志**：模板创建 / 修改 / 删除关键操作不写 AuditLog——合规审计场景需自接入
 
 ## 依赖

--- a/kudos-ms/kudos-ms-msg/kudos-ms-msg-sql/README.md
+++ b/kudos-ms/kudos-ms-msg/kudos-ms-msg-sql/README.md
@@ -1,23 +1,98 @@
 # kudos-ms-msg-sql
 
-Msg 原子服务的 Flyway 迁移脚本——只放 `*.sql`，无 Kotlin 代码。
+Msg 原子服务的 **Flyway 资源模块**——只放 `*.sql`，没有 Kotlin 编译产物。
+`build.gradle.kts` 是空 `dependencies { }`，靠消费侧（`msg-api-public` / `msg-api-internal`）
+的 Flyway 配置在 boot 时扫描 `classpath:sql/msg/{dialect}/`。
 
-## 表结构（要点）
+## 目录结构
 
-| 表 | 说明 |
-|---|---|
-| `msg_template` | 消息模板 |
-| `msg_instance` | 模板渲染后的具体消息 |
-| `msg_send` | 发送调度记录 |
-| `msg_receive` | 一对一投递记录 |
-| `msg_receiver_group` | 接收组 |
-| `msg_unreceived` | 失败 / 未送达跟踪 |
+```
+resources/sql/msg/
+└── h2/                    ← 当前**只有 h2 一份脚本**；mysql / postgres / oracle 方言尚未补齐
+    ├── V1.0.0.0..6        ← 系统配置 / 字典 / i18n 引导
+    ├── V1.0.0.20..25      ← msg_* 业务表 DDL
+    (中间 V1.0.0.7..19 保留给后续脚本)
+```
+
+## 迁移清单
+
+| 文件 | 作用 |
+|------|------|
+| `V1.0.0.0__insert_sys_micro_service.sql` | 注册 `msg` 微服务（`atomic_service=true`、`context=/api/msg`、`built_in=true`） |
+| `V1.0.0.1__insert_sys_dict.sql` | 创建 8 个字典类型：`publish_method` / `receiver_group_type` / `send_status` / `tmpl_type` / `auto_event_type` / `manual_event_type` / `params` / `receive_status` |
+| `V1.0.0.2__insert_sys_dict_item.sql` | 字典项落库——见下方"字典与枚举对齐" |
+| `V1.0.0.3__insert_sys_cache.sql` | ⚠️ **整文件被注释**——`USER_ORG_IDS_BY_USER_ID` 缓存定义保留为占位，待启用 |
+| `V1.0.0.4__insert_sys_resource.sql` | ⚠️ **仅一行注释 "消息中心 Bell,"**——sys_resource 入库尚未写 |
+| `V1.0.0.5__insert_sys_param.sql` | ⚠️ **空文件**——msg 服务暂无 sys_param 默认值 |
+| `V1.0.0.6__insert_sys_i18n.sql` | 字典名/字典项的 `zh_CN` / `zh_TW` / `en_US` 三语翻译（约 160 行） |
+| `V1.0.0.20__init_msg_template.sql` | `msg_template` DDL |
+| `V1.0.0.21__init_msg_instance.sql` | `msg_instance` DDL（FK → `msg_template.id`） |
+| `V1.0.0.22__init_msg_receiver_group.sql` | `msg_receiver_group` DDL（含完整审计列、`uq_msg_receiver_group__type_code` 唯一索引） |
+| `V1.0.0.23__init_msg_send.sql` | `msg_send` DDL（FK → `msg_instance.id`） |
+| `V1.0.0.24__init_msg_receive.sql` | `msg_receive` DDL（FK → `msg_send.id`） |
+| `V1.0.0.25__init_msg_unreceived.sql` | `msg_unreceived` DDL（FK → `msg_send.id`，含 `idx_msg_unreceived_send` / `idx_msg_unreceived_receiver_unresolved`） |
+
+## 表关系
+
+```
+msg_template ──┐
+               │ template_id (nullable)
+               ▼
+       msg_instance ──┐
+                      │ instance_id (NOT NULL)
+                      ▼
+              msg_send ──┬─→ msg_receive    (一收件人一行)
+                         └─→ msg_unreceived (失败补偿，含 retry_count / resolved)
+
+msg_receiver_group ── 独立 lookup 表，
+                     msg_send.receiver_group_id 是 VARCHAR(36) 软引用，
+                     未建 FK，由应用层保证一致性。
+```
+
+## 字典与枚举对齐
+
+| dict_type | 字典项 | 对应 Kotlin 枚举 |
+|-----------|--------|------------------|
+| `publish_method` | `email` / `sms` / `siteMsg` / `all_user` | `MsgPublishMethodEnum`（仅 EMAIL / SMS / SITE_MSG）—— `all_user` 在 SQL 端有定义，枚举侧暂未覆盖 |
+| `receiver_group_type` | `all_front` / `all_back` / `online_front` / `online_back` / `offline_front` / `offline_back` / `dept` / `role` / `tag` / `guest` / `user` (11 项) | （无独立枚举，运行时按字符串处理） |
+| `send_status` | `00` / `01` / `11` / `21` / `22` / `31` / `32` / `33` | `MsgSendStatusEnum` 完整对齐 |
+| `receive_status` | `01` / `11` / `12` / `21` | `MsgReceiveStatusEnum` 完整对齐 |
+| `tmpl_type` | `auto` / `manual` | （无枚举，字符串） |
+
+**字典码与枚举耦合**：每次改 Kotlin 枚举的 `dictCode` 都得同步 SQL，否则运行时拿到字符串
+匹配不上枚举。建议两边都加 unit test 校验集合相等。
+
+## 已知限制 / 后续工作
+
+- ❗ **只有 h2 方言**——mysql / postgres / oracle 子目录尚未创建；生产部署需先补齐对应 DDL。
+  h2 用 `RANDOM_UUID()`、`varchar`（无界）、`TIMESTAMP(6)` 等非 ANSI 语法，直接搬到其他
+  方言会失败
+- ❗ **`msg_template.content` 是 `varchar`（无界）**——h2 默认转 `CLOB`，但 mysql 移植到
+  `VARCHAR(?)` 时需要确定上限或改 `TEXT`。配合 msg-core 已知问题（"模板内容大小无上限"），
+  应用层 form 校验需先加 maxLength
+- ❗ **缺索引**：`msg_template`（无 tenant_id 索引）、`msg_instance`（无 template_id /
+  tenant_id 索引）、`msg_send`（无 tenant_id / send_status_dict_code 索引）、
+  `msg_receive`（无 receiver_id / receive_status 索引）。状态查询 / 多租户隔离查询会
+  全表扫
+- ❗ **审计列不一致**：`msg_receiver_group` 有完整 `create_user_id` / `create_user_name` /
+  `create_time` / `update_*` 六列；其他 5 张 msg_* 表只有 `create_time` / `update_time`，
+  缺操作人。合规审计场景需先补列
+- ❗ **`msg_send.receiver_group_id` 是 VARCHAR(36)，未对 `msg_receiver_group.id`（CHAR(36)）
+  建 FK**——类型不一致 + 无约束，应用层若写入错误 id 不会立即报错
+- ❗ **时间戳精度不一致**：`msg_template` / `msg_instance` 用 `TIMESTAMP`，其他用 `TIMESTAMP(6)`
+- ❗ **`msg_instance.valid_time_end` 默认 `now()+99999`**——h2 把这个数字按"天"算（约 273 年），
+  跨方言移植语义会改变，建议显式给业务侧默认值
+- ❗ **无软删列**——全部物理删；接收记录被删后无法做"用户曾经收到过这条消息"的合规追溯
+- ❗ **V1.0.0.3 / V1.0.0.4 / V1.0.0.5 三脚本都是空 / 占位**——文件已占版本号，后续真要写内容
+  需新版本号（`V1.0.0.26+`），不能复用
 
 ## 约定
 
 - 表前缀 `msg_`
-- Flyway baseline + V_*_* / R_*_* 命名
-- 内置模板（如系统欢迎消息）走 `R_*` 可重复脚本
+- 版本号空间：`V1.0.0.0..6` 给系统数据 / 字典，`V1.0.0.20+` 给业务表 DDL，中间留 hole
+- 命名：`fk_msg_<child>`、`idx_msg_<table>_<purpose>`、`uq_msg_<table>__<columns>`
+- 内置模板 / R_*\_\* 可重复脚本：当前尚未引入，欢迎消息等首批模板由 msg-core 服务层
+  按 boot 初始化（待确认）
 
 ## 依赖
 


### PR DESCRIPTION
Bring msg-common, msg-sql, msg-client, msg-api-admin, msg-api-public, msg-api-internal, and the aggregate msg/README up to the same depth as the existing msg-core README. Findings worth flagging:

- api-public / api-internal gradle does NOT depend on api-admin, yet the old READMEs claimed they do — controllers are not actually wired in those processes. Mirrored in the user-api-* tree.
- IMsgReceiverGroupApi interface body is empty; client / api-internal correspondingly lack proxy + controller.
- MsgPublishMethodEnum is missing the all_user dict item present in SQL.
- V1.0.0.3 / V1.0.0.4 / V1.0.0.5 are empty / placeholder migrations.
- msg-sql only ships h2 dialect; mysql/pg variants and key indexes are missing.
- All four *ErrorCodeEnum types contain only UNSPECIFIED.
- msg-core README "content is TEXT column" wording corrected to match the actual h2 varchar (unbounded / CLOB).