### PR TITLE
docs(ms-auth): substantive READMEs for all submodules + root naming c…

### DIFF
--- a/kudos-ms/kudos-ms-auth/README.md
+++ b/kudos-ms/kudos-ms-auth/README.md
@@ -13,13 +13,13 @@
 
 | 子模块 | 说明 |
 |--------|------|
-| [kudos-ms-auth-common](kudos-ms-auth-common/README.md) | 跨模块共享契约 |
-| kudos-ms-auth-sql | Flyway 迁移脚本（auth 库表） |
-| kudos-ms-auth-core | DAO / Service / 缓存 / API 实现 |
-| kudos-ms-auth-api-admin | 管理端 REST（`/api/admin/auth/...`） |
-| kudos-ms-auth-api-public | 对外 Web 启动入口 |
-| kudos-ms-auth-api-internal | 对内 Provider 启动入口 |
-| kudos-ms-auth-client | Feign 代理 + 降级 |
+| [kudos-ms-auth-common](kudos-ms-auth-common/README.md) | 跨模块共享契约（`IAuthRoleApi` / `IPermittedResource` / VO / 错误码） |
+| [kudos-ms-auth-sql](kudos-ms-auth-sql/README.md) | Flyway 迁移脚本（`V1.0.0.20+` 为 `auth_*` 表 DDL；前段为 `sys_*` 种子） |
+| [kudos-ms-auth-core](kudos-ms-auth-core/README.md) | DAO / Service / 多级缓存 / 事件订阅 / `IAuth*Api` 实现 |
+| [kudos-ms-auth-api-admin](kudos-ms-auth-api-admin/README.md) | 管理端 REST：`/api/admin/auth/role/**`、`/api/admin/auth/group/**` |
+| [kudos-ms-auth-api-public](kudos-ms-auth-api-public/README.md) | 对外 Web 启动入口 + `PermittedResourceController`（当前用户视图） |
+| [kudos-ms-auth-api-internal](kudos-ms-auth-api-internal/README.md) | 对内 Provider 启动入口 + `AuthRoleInternalController`（Nacos / interservice 缓存） |
+| [kudos-ms-auth-client](kudos-ms-auth-client/README.md) | `IAuthRoleProxy` Feign 代理 + `AuthRoleFallback` 降级 |
 
 ---
 
@@ -65,3 +65,23 @@
   （详见 `auth_group` 的层级 path 字段）
 - 与 `kudos-ms-sys` 的关系：`sys.sys_resource` 是资源主数据，本模块只持有"哪个角色绑了哪些资源 id"
 - 与 `kudos-ms-user` 的关系：`user.sys_user` 是用户主数据，本模块只持有"哪个用户属于哪些组 / 哪些角色"
+
+---
+
+## 命名与约定（跨模块）
+
+- **原子服务名**：`SysConsts.ATOMIC_SERVICE_NAME = "auth"`——所有 Feign 服务名、缓存 namespace、
+  Flyway 表前缀、日志 `service` 字段都以此为锚点。
+- **领域 API**：`common` 中 `IAuth*Api` 由 `core` 中 `Auth*Api` 实现；`client` 中 `IAuth*Proxy`
+  继承同一接口并通过 Feign 调用远程服务。**目前仅 `role` 对外**——`group` 域只通过 admin HTTP
+  暴露，无 Feign 接口。
+- **方法级 Feign 路由**：所有 `IAuth*Api` 的方法上挂 `@GetMapping("/api/internal/auth/...")`
+  / `@PostMapping`，接口类型上**不**放 `@RequestMapping`；`auth-api-internal` 的 Controller 直接
+  `implements IAuth*Api`，路径自动继承——签名漂移可在编译期暴露。
+- **管理端 vs 内部**：`/api/admin/auth/**` 仅由 `api-admin` 承载，`/api/internal/auth/**` 仅由
+  `api-internal` 与 `api-public` 内的 `PermittedResourceController` 承载；两套前缀在网关层应
+  分别路由。
+- **跨服务种子数据**：`auth-sql` 的 `V1.0.0.0–V1.0.0.6` 是写入 `sys_*` 表的菜单 / 字典 / 缓存
+  登记 / 参数 / i18n 文案——遵循"被写入方负责 DDL，写入方负责 INSERT"。
+
+具体类名与边界以各子模块源码为准。

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-api-admin/README.md
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-api-admin/README.md
@@ -1,19 +1,106 @@
 # kudos-ms-auth-api-admin
 
-Auth 服务的**管理端 REST 控制器层**。映射到 `/api/admin/auth/...` 等路径，对接前端管理后台。
+## 定位
 
-## 内容
+鉴权（`auth`）原子服务的**管理端 HTTP API 层**：在 `kudos-ms-auth-core` 之上提供**面向控制台 /
+管理网关**的 Spring MVC 控制器，路径统一落在 **`/api/admin/auth/...`** 下。与 `api-public` /
+`api-internal` 的区别在于：本模块**包含具体 Controller 类**，而不仅是启动入口。
 
-- `*Controller` 类——一个领域（role / group / group-user / role-user / role-resource）一个 controller
-- 控制器调用 `auth-core` 的 `IAuth*Service`，不直接接触 DAO
-- 返回类型直接用 `auth-common` 的 VO
+---
 
-## 依赖
+## 入口与自动配置
 
-- `kudos-ms-auth-core`（含 Service 接口与实现）
-- `kudos-ability-web-springmvc`（基础 controller 能力）
+| 类型 | 类 | 说明 |
+|------|----|------|
+| 启动类 | `AuthApiAdminApplication` | `@EnableKudos`，可作为独立 Spring Boot `main` 运行 |
+| 自动配置 | `AuthApiAdminAutoConfiguration` | `@ComponentScan("io.kudos.ms.auth.api.admin")`，`IComponentInitializer` 组件名 **`kudos-ms-auth-api-admin`** |
 
-## 部署形态
+依赖 **`kudos-ability-web-springmvc`**，继承工程内通用 Controller 基类（如 `BaseCrudController`）
+实现标准 CRUD 与扩展接口。
 
-`api-admin` 自身**不是**应用启动模块——它只贡献 controller。实际启动入口在
-`auth-api-public`（web 形态）/ `auth-api-internal`（provider 形态）。
+**包结构**：在 **`io.kudos.ms.auth.api.admin.controller`** 下再按业务模块分子包
+**`...controller.<模块>`**（与 `common` / `core` 模块名对齐）——`controller/role/`、`controller/group/`；
+启动与扫描仍在 **`...api.admin.init`**。
+
+---
+
+## 控制器一览
+
+`auth` 域 admin 当前仅有两个 Controller（与 `common` 的两个领域包对齐），每个 Controller
+承担"主资源 + 它的所有关联关系"：
+
+| 控制器 | 基础路径 | 职责概要 |
+|--------|----------|----------|
+| `AuthRoleAdminController` | `/api/admin/auth/role` | 角色 CRUD + 启用状态、角色 ↔ 用户、角色 ↔ 资源 |
+| `AuthGroupAdminController` | `/api/admin/auth/group` | 用户组 CRUD、组 ↔ 用户、组 ↔ 角色 |
+
+### Endpoint 命名约定
+
+两个 Controller 都遵循同一套关联关系操作 verb：
+
+| 形态 | URI 段 | 语义 |
+|------|--------|------|
+| 列举目标 id | `GET /list<Target>Ids` | 例：`/role/listUserIds?roleId=...` 查角色下所有用户 id |
+| 反查持有方 | `GET /list<Holder>IdsBy<Target>` | 例：`/role/listRoleIdsByUser?userId=...` 查用户持有的所有角色 |
+| 批量绑定 | `POST /bind<Target>s` | 例：`/role/bindUsers` body 含 `(roleId, userIds[])` |
+| 单条解绑 | `DELETE /unbind<Target>` | 例：`/role/unbindUser?roleId=...&userId=...` |
+| 主资源开关 | `PUT /updateActive` | 仅 role：禁用 / 启用角色 |
+
+`AuthRoleAdminController` 的关联面覆盖 **user / resource** 两种 target；
+`AuthGroupAdminController` 的关联面覆盖 **user / role** 两种 target。
+
+> **CRUD 主路径**继承自 `BaseCrudController`——`POST /` / `PUT /` / `DELETE /{id}` /
+> `GET /{id}` / `GET /list` 等不在本 README 列出，以基类为准。
+
+---
+
+## 依赖关系
+
+```
+kudos-ms-auth-api-admin
+    └── kudos-ms-auth-core
+            ├── kudos-ms-auth-sql
+            └── kudos-ms-auth-common
+```
+
+依赖 **`kudos-ability-web-springmvc`** 提供基础 Controller 能力；不直接依赖 DAO / Cache，
+所有调用都委托给 `core` 暴露的 `IAuth*Service`。
+
+---
+
+## 与 api-public / api-internal 的配合
+
+- **api-admin**：承载**管理 REST**（本模块）。
+- **api-public**：提供**对外 Web 进程**的 `main` 与极薄扫描包，同时也挂载
+  `PermittedResourceController`（当前用户视角的菜单查询）；可执行应用通常
+  **同时依赖 admin + core + public**，从而在网关后对外暴露 `/api/admin/auth/**` 与
+  `/api/internal/auth/permittedResource/**`。
+- **api-internal**：提供**对内 Provider** 形态与 Nacos 等栈，挂载 `AuthRoleInternalController`
+  实现 `IAuthRoleApi`，供其他微服务通过 Feign 调用。
+
+部署拓扑以实际可执行模块（如 gateway、ams-*-api-web）的 `build.gradle.kts` 为准。
+
+---
+
+## 已知限制 / 安全考量
+
+> 与 [auth-core 已知限制](../kudos-ms-auth-core/README.md#已知限制--后续工作) 同源——管理端
+> 是这些风险最终暴露的入口：
+
+- ❗ **零 `@PreAuthorize`**：所有 admin 端点都依赖**网关 / 外部鉴权过滤器**做访问控制。
+  `bindUsers` / `bindRoles` / `bindResources` / `updateActive` 等敏感写入端点若网关挂了
+  或路由错配，可被未授权调用方直接命中。
+- ❗ **审计日志接入不一致**：`bind*` / `unbind*` / `updateActive` 等关键鉴权变更目前未统一
+  接 `AuditLogTool`——生产合规场景需自行接入。
+- ❗ **批量写入未限流**：`bindUsers(roleId, userIds[])` 在 `userIds` 极大时（如导入 10 万用户）
+  会触发跨服务 `UserAccountHashCache.getUsersByIds` 雪崩——上游需做尺寸校验。
+
+---
+
+## 扩展建议
+
+- 新增管理接口：优先在 **core** 完成 `IAuth*Service` 能力，再在本模块新增 `*AdminController`，
+  保持 VO 仅来自 **common**。
+- 若 `group` 需要对外暴露给其他微服务，先在 `auth-common.group.api` 加 `IAuthGroupApi`、
+  在 `auth-client` 加 `IAuthGroupProxy`，再在 `auth-api-internal` 加 `AuthGroupInternalController`——
+  admin 与 internal 路径互不重叠。

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-api-internal/README.md
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-api-internal/README.md
@@ -1,27 +1,116 @@
 # kudos-ms-auth-api-internal
 
-Auth 服务**对内 Provider 进程**的启动入口与自动配置。
+## 定位
 
-## 内容
+鉴权（`auth`）原子服务的**对内服务 Provider 进程**入口与自动配置。**与 sys-api-internal 的差异**：
+本模块**包含一个真实 Controller**——`AuthRoleInternalController`，实现 `IAuthRoleApi` 把角色查询 /
+鉴权判断等能力暴露给其他微服务通过 Feign 调用。除此之外**额外引入服务发现、配置中心与跨服务
+缓存 Provider** 等能力，面向**集群内部**调用场景。
 
-- `AuthApiProviderApplication` —— Spring Boot `main()`
-- 与 `api-public` 对称——但作为微服务间 Feign 调用的 provider，配独立的网络入口
-- 通常关闭面向最终用户的 web 路径，只保留对内 API
+---
+
+## 入口与自动配置
+
+| 类型 | 类 | 说明 |
+|------|----|------|
+| 启动类 | `AuthApiProviderApplication` | `@EnableKudos`，`main` 启动 Spring Boot |
+| 自动配置 | `AuthApiProviderAutoConfiguration` | `@ComponentScan("io.kudos.ms.auth.api.internal")`，`IComponentInitializer` 组件名 **`kudos-ms-auth-api-internal`** |
+
+`io.kudos.ms.auth.api.internal` 下当前有两个包：
+
+- `init/` —— `Application` + `AutoConfiguration`
+- `controller/role/AuthRoleInternalController` —— `implements IAuthRoleApi`，路径完全继承自
+  接口方法级注解（`/api/internal/auth/role/...`）
+
+---
+
+## 控制器一览
+
+| 控制器 | 实现接口 | 职责 |
+|--------|----------|------|
+| `AuthRoleInternalController` | `IAuthRoleApi`（auth-common.role.api） | 把 `core` 的 `AuthRoleApi` Bean 通过 HTTP 暴露给 `auth-client.IAuthRoleProxy`：`getRoleById` / `getRolesByIds` / `getRoleId` / `getRoleUsers` / `getUserIdsByRoleCode` / `getRoleResources` / `hasResource` / `hasRole` / `getUserResourceIds` 等 |
+
+> **路径继承自方法级注解**——本 Controller 类上**没有** `@RequestMapping`，所有路径都在
+> `IAuthRoleApi` 的方法级 `@GetMapping("/api/internal/auth/role/...")` 上。这样 Feign 代理与服务端
+> 路径自动对齐，新增方法时只需改 `common`。
+
+---
+
+## Gradle 依赖（要点）
+
+在 **`kudos-ms-auth-core`** 与 **`kudos-ability-web-springmvc`** 之外，本模块额外依赖：
+
+| 依赖 | 作用 |
+|------|------|
+| `kudos-ability-cache-interservice-provider` | 跨服务缓存的 **Provider 侧**能力（其他服务的缓存能在本服务发生写入后被失效） |
+| `kudos-ability-distributed-discovery-nacos` | 服务注册与发现（Nacos） |
+| `kudos-ability-distributed-config-nacos` | 配置中心（Nacos） |
+
+因此**可执行 fat jar** 若以本模块为入口，通常具备**注册到 Nacos、拉取远程配置、参与服务间
+缓存协议**等能力；具体行为以 Kudos 各 ability 模块文档与配置为准。
+
+---
+
+## 依赖关系（概念）
+
+```
+kudos-ms-auth-api-internal
+    ├── kudos-ms-auth-core
+    │       ├── kudos-ms-auth-sql
+    │       └── kudos-ms-auth-common
+    ├── kudos-ability-web-springmvc
+    ├── kudos-ability-cache-interservice-provider
+    ├── kudos-ability-distributed-discovery-nacos
+    └── kudos-ability-distributed-config-nacos
+```
+
+---
 
 ## 部署形态
 
 跑两个独立 JVM：
-- `api-public` 对外暴露管理端 HTTP
-- `api-internal` 给其他微服务（如 user / sys / msg）通过 Feign 调用
+- `api-public` 对外暴露管理端 HTTP（含 `PermittedResourceController`，若组合 admin 还含
+  `/api/admin/auth/**`）
+- `api-internal` 给其他微服务（如 user / sys / msg / 业务）通过 Feign 调用
+  `/api/internal/auth/role/**`
 
-这种分离让"控制台流量"与"服务间流量"在网络层 / 监控 / SLI 上能分别治理。
+这种分离让"控制台流量"与"服务间流量"在**网络层 / 监控 / SLI** 上能分别治理；同时
+api-internal 的 Nacos 依赖也只会出现在内网进程。
 
-## 依赖
+---
 
-同 `api-public`：core + api-admin（其实 internal 通常不挂 admin controller，但代码里仍引入
-以共享 Spring 装配）+ web 栈。
+## 与 api-public 的对比
+
+| 维度 | api-public | api-internal |
+|------|------------|--------------|
+| 典型场景 | 对外 Web / 网关后管理端 | 对内 Provider / 服务间调用 |
+| Nacos / interservice 缓存 | 不强制 | 依赖中默认引入 |
+| 源码中的 Controller | `PermittedResourceController`（当前用户视图） | `AuthRoleInternalController`（无状态 RPC） |
+| 路径前缀 | `/api/internal/auth/permittedResource/*` + 组合 admin 时的 `/api/admin/auth/**` | `/api/internal/auth/role/*` |
+
+---
 
 ## 已知限制
 
-- ❗ `api-internal` 与 `api-public` 的实际边界目前由 yml 配置决定（端口 / actuator 暴露面），
-  代码层未硬分隔——业务侧需自行约束哪些路径"内部专用"
+- ❗ **`api-internal` 与 `api-public` 的实际边界由 yml 配置决定**（端口 / actuator 暴露面 /
+  网关路由），**代码层未硬分隔**——若上层聚合不当，两个进程可能加载同一个 Controller。
+  业务侧需自行约束"哪些路径内部专用"，例如：
+  - 网关只把 `/api/admin/**` 转发到 public 进程
+  - 内部 Feign 调用走独立的 service registry 标签
+- ❗ **`AuthRoleInternalController` 无 `@PreAuthorize`**：依赖 mTLS / 内网网络隔离做边界
+  防护。`hasResource` / `getUserResourceIds` 等鉴权关键判定如果被非授信调用方命中，
+  返回结果可被用于权限旁路侦察。
+- ❗ **`group` 域无 Internal Controller**：当前 group 不对外，所有组操作只能通过 admin
+  HTTP。若后续业务需要"跨服务查用户所在组"，需同步补 `IAuthGroupApi`（common）→
+  `IAuthGroupProxy`（client）→ `AuthGroupInternalController`（本模块）。
+
+---
+
+## 扩展建议
+
+- 新增 internal 端点：在 `auth-common` 对应 `Api` 接口新增方法（带方法级 `@GetMapping` /
+  `@PostMapping`），在 `auth-core` 实现 `*Api` Bean，然后在本模块对应 Controller 重写
+  override 即可——不要在 Controller 写业务逻辑。
+- 部署为 Provider 节点时，需与 **Feign 客户端**（`kudos-ms-auth-client`）及**网关路由**
+  中的服务名（`auth-role`）、上下文路径保持一致。
+- 纯本地开发若不需要 Nacos，可优先用 **api-public + api-admin** 组合，避免强依赖注册中心。

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-api-public/README.md
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-api-public/README.md
@@ -1,12 +1,40 @@
 # kudos-ms-auth-api-public
 
-Auth 服务**对外 Web 进程**的启动入口与自动配置。
+## 定位
 
-## 内容
+鉴权（`auth`）原子服务的**对外 Web 进程**入口与自动配置。**与 sys-api-public 的差异**：本模块
+**包含一个真实 Controller**——`PermittedResourceController`，对外暴露"当前登录用户可见菜单 /
+资源"的能力（`IPermittedResource` 的实现端）。除此之外的管理端 REST 仍由
+`kudos-ms-auth-api-admin` 承担，本模块通过组合依赖一并装载。
 
-- `AuthApiWebApplication` —— Spring Boot `main()`
-- 自动配置：装载 auth-core + auth-api-admin + web 全栈（springmvc + filter + interceptor）
-- 默认监听管理端 HTTP 路径
+---
+
+## 入口与自动配置
+
+| 类型 | 类 | 说明 |
+|------|----|------|
+| 启动类 | `AuthApiWebApplication` | `@EnableKudos`，`main` 启动 Spring Boot |
+| 自动配置 | `AuthApiWebAutoConfiguration` | `@ComponentScan("io.kudos.ms.auth.api.public")`，`IComponentInitializer` 组件名 **`kudos-ms-auth-api-public`** |
+
+`io.kudos.ms.auth.api.public` 下当前有两个包：
+
+- `init/` —— `Application` + `AutoConfiguration`
+- `controller/platform/PermittedResourceController` —— `implements IPermittedResource`，
+  路径完全继承自接口方法级注解（典型为 `/api/internal/auth/permittedResource/...`）
+
+---
+
+## 控制器一览
+
+| 控制器 | 实现接口 | 职责 |
+|--------|----------|------|
+| `PermittedResourceController` | `IPermittedResource`（auth-common.platform.api） | `getMenusForCurrentUser` —— 拿当前请求上下文里的 `userId`，按"用户 → 组 → 角色 → 资源"链路拼出菜单树（`List<MenuTreeNode>`） |
+
+> 之所以放在 `api-public` 而非 `api-internal`：**当前用户视图**是 Web 进程内的请求级 API
+> （要从 `RequestContext` 取 `userId` / `tenantId`），不是无状态的 RPC——放在 internal 用 Feign
+> 调会丢上下文。
+
+---
 
 ## 启动
 
@@ -14,25 +42,59 @@ Auth 服务**对外 Web 进程**的启动入口与自动配置。
 java -jar auth-api-public-<version>.jar
 ```
 
-或本仓库测试：
+或本仓库本地运行：
 
 ```bash
 ./gradlew :kudos-ms:kudos-ms-auth:kudos-ms-auth-api-public:bootRun
 ```
 
-## 依赖
+---
 
-- `kudos-ms-auth-api-admin`（controllers）
-- `kudos-ms-auth-core`（业务实现）
-- `kudos-ability-web-springmvc`（web 栈）
-- Spring Boot starter 与各项 starter（cache / 数据库等通过 core 间接带入）
+## Gradle 依赖
 
-## 与 api-internal 的区别
+```kotlin
+dependencies {
+    api(project(":kudos-ms:kudos-ms-auth:kudos-ms-auth-core"))
+    api(project(":kudos-ability:kudos-ability-web:kudos-ability-web-springmvc"))
+    testImplementation(project(":kudos-test:kudos-test-container"))
+}
+```
 
-| 维度 | api-public | api-internal |
-|---|---|---|
-| 暴露面 | 管理端 HTTP / 公开 web | 内网 Feign provider |
-| 启用 controller | 全部 | 全部，但通常配独立网络入口 |
-| 适用场景 | 用户 / 控制台 | 微服务间调用 |
+依赖 **`core`** 间接拉入 `auth-sql` / `auth-common` 与所有缓存 / DAO / Service Bean；
+**`web-springmvc`** 拉入 Filter / Interceptor / 异常映射 / 序列化等 Web 栈。
+**不强制依赖 `api-admin`**——若需要同时对外暴露 `/api/admin/auth/**`，由上层聚合
+（如 `*-api-web`）一并引入 `api-admin`。
 
-具体差异看各自 `Application` + yml。
+---
+
+## 依赖关系（概念）
+
+```
+kudos-ms-auth-api-public
+    ├── kudos-ms-auth-core
+    │       ├── kudos-ms-auth-sql
+    │       └── kudos-ms-auth-common
+    └── kudos-ability-web-springmvc
+```
+
+---
+
+## 与 api-admin / api-internal 的对比
+
+| 维度 | api-public | api-admin | api-internal |
+|------|------------|-----------|--------------|
+| 主类 | `AuthApiWebApplication` | `AuthApiAdminApplication` | `AuthApiProviderApplication` |
+| 是否含 Controller | 是（`PermittedResourceController`，1 个） | 是（`AuthRoleAdminController` / `AuthGroupAdminController`） | 是（`AuthRoleInternalController`，1 个） |
+| 额外分布式能力 | 无（仅 core + MVC） | 无 | Nacos + interservice 缓存 |
+| 暴露面 | 当前用户视图 + 管理 HTTP（由 admin 组合时） | 管理 REST `/api/admin/auth/**` | 服务间 Feign `/api/internal/auth/**` |
+| 适用场景 | 控制台前端 / 网关后用户路径 | 控制台前端 | 微服务间调用 |
+
+---
+
+## 扩展建议
+
+- 若需"纯 Web 网关入口"专用配置（如自定义 Filter），可放在 `io.kudos.ms.auth.api.public`
+  下并由本模块扫描；**业务管理接口仍建议放在 api-admin**，便于权限与路由前缀统一。
+- 新增"当前用户视图"型接口（同样需要 RequestContext）：在 `controller/platform/` 下扩展，
+  在 `auth-common.platform.api` 加对应接口契约，保持 controller 类只做"取上下文 + 委托
+  `core` 实现"。

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-client/README.md
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-client/README.md
@@ -1,28 +1,110 @@
 # kudos-ms-auth-client
 
-Auth 服务的 **Feign 客户端代理 + 降级处理**——让其他微服务（user / sys / msg / 业务）通过
-统一 Kotlin 接口调用远端 auth。**只依赖 `auth-common`**，不打包 core，避免调用方意外加载
-业务实现。
+## 定位
 
-## 内容
+**其他微服务**（user / sys / msg / 业务）通过 **OpenFeign** 远程调用鉴权（`auth`）原子服务时
+的**客户端模块**：仅依赖 **`kudos-ms-auth-common`** 与 Feign 能力模块，**不**依赖
+`kudos-ms-auth-core`，避免将 ORM / 缓存实现等打入调用方 classpath。
 
-- `*Proxy : IAuth*Api` —— Feign 接口；继承自 common 的契约接口，签名与 server 端实现一致
-- `*Fallback` —— 调用失败时的降级实现（继承 `AbstractFeignFallbackSupport`：读接口 warn +
-  安全默认值；写接口 error + 失败值）
+每个 **`IAuth*Proxy`** 继承 `common` 中对应的 **`IAuth*Api`**，保证**本地注入 `IAuth*Api`
+与远程 Feign**在方法签名上完全一致——服务端 `core` 实现切换为 client 远程代理时调用方无需改码。
 
-业务侧引入：
+---
+
+## 包结构
+
+在 **`io.kudos.ms.auth.client.<业务模块>`** 下与 **common / core** 的模块名对齐；每个模块内
+再分 **`proxy`**（`IAuth*Proxy`，Feign）与 **`fallback`**（`Auth*Fallback`）子包。
+
+典型形态：
+
+```kotlin
+@FeignClient(name = "auth-role", fallback = AuthRoleFallback::class)
+interface IAuthRoleProxy : IAuthRoleApi
+```
+
+`name` 为注册中心中的**服务名**（或网关 / 配置中心的映射名），需与**提供 auth 能力的进程**
+在注册中心中的名称一致。
+
+| Proxy | Feign `name` | Fallback |
+|-------|-------------|----------|
+| `IAuthRoleProxy` | `auth-role` | `AuthRoleFallback` |
+
+> **当前只暴露 `role` 一个 Proxy**——`group` 域目前没有跨服务调用方，因此 `auth-common` 未
+> 定义 `IAuthGroupApi`，client / api-internal 也就没有对应的 Proxy / Controller。若后续业务
+> 需要"用户组 → 跨服务展示"等能力，按 `role` 模式同步新增：
+> `auth-common.group.api.IAuthGroupApi` → `auth-client.group.proxy.IAuthGroupProxy` →
+> `auth-api-internal.controller.group.AuthGroupInternalController`。
+
+---
+
+## Fallback 约定
+
+`Auth*Fallback` 继承自 `kudos-ability-distributed-client-feign` 的 `AbstractFeignFallbackSupport`：
+
+- **读接口**：记录 `warn` 日志 + 返回**安全默认值**（`null` / 空 `Map` / 空 `List` / `false`），
+  保证调用方继续执行而不是级联抛错。
+- **写接口**：记录 `error` 日志 + 返回**失败值**（写入 `false` / `0` 等），由调用方判断后续
+  补偿逻辑。
+
+具体回填行为以 `AuthRoleFallback` 实现为准。
+
+---
+
+## Gradle 依赖
 
 ```kotlin
 dependencies {
-    implementation(project(":kudos-ms:kudos-ms-auth:kudos-ms-auth-client"))
+    api(project(":kudos-ms:kudos-ms-auth:kudos-ms-auth-common"))
+    api(project(":kudos-ability:kudos-ability-distributed:kudos-ability-distributed-client:kudos-ability-distributed-client-feign"))
+    testImplementation(project(":kudos-test:kudos-test-container"))
 }
 ```
 
-然后 `@Autowired private val authRoleProxy: IAuthRoleProxy`。
+- **`kudos-ms-auth-common`**：契约与序列化类型（`IAuthRoleApi` + 全套 VO）。
+- **`kudos-ability-distributed-client-feign`**：Feign 注解 + 上下文透传（traceId / tenantId）
+  + 降级基类（`AbstractFeignFallbackSupport`）。
 
-## 依赖
+---
 
-- `kudos-ms-auth-common`（契约与 VO 序列化对齐）
-- `kudos-ability-distributed-client-feign`（Feign 注解 + 上下文透传 + 降级基类）
+## 调用方接入
 
-不依赖 auth-core——`auth-client` 是"远端调用对端"的薄包装，本地没有任何业务逻辑。
+```kotlin
+@Configuration
+@EnableFeignClients(basePackages = ["io.kudos.ms.auth.client"])
+class FeignConfig
+
+@Service
+class MyBizService(
+    private val authRoleProxy: IAuthRoleProxy,
+) {
+    fun canRead(userId: String, resourceId: String): Boolean =
+        authRoleProxy.getUserResourceIds(userId).contains(resourceId)
+}
+```
+
+1. **启用 Feign 扫描**：调用方 Spring Boot 应用需能扫描到 `io.kudos.ms.auth.client`（含各模块
+   下的 `proxy`；或通过 `@EnableFeignClients(basePackages = ...)` 指定）。
+2. **服务发现**：`name = "auth-role"` 需与 Nacos / Eureka 等中的实例一致；本地开发可用固定 URL
+   配置（视 Spring Cloud 版本而定）。
+3. **契约变更**：修改 `IAuthRoleApi` 时须**同步**检查 `auth-core` 实现、`AuthRoleFallback`
+   与 `auth-api-internal/AuthRoleInternalController`——三者签名脱节会让 Feign 反序列化失败。
+
+---
+
+## 与其他子模块的关系
+
+| 模块 | 关系 |
+|------|------|
+| **common** | Proxy 继承 `IAuth*Api`，请求 / 响应体为同一套 VO |
+| **core** | 在**服务端**实现 `IAuth*Api`；客户端**不引用** core |
+| **api-internal** | 通过 `*InternalController : IAuth*Api` 在服务端暴露同一套路径，Feign 调用最终落到这里 |
+
+---
+
+## 扩展建议
+
+- 新增远程能力：先在 **common** 定义 `IAuth*Api` 与方法级 `@GetMapping`/`@PostMapping`，
+  再在 **core** 实现，最后在本模块对应业务目录下新增 `proxy/IAuth*Proxy` 与
+  `fallback/Auth*Fallback`，保持四者（common / core / client.proxy / client.fallback）一一对应。
+- 不要在本模块写业务逻辑——`client` 是"远端调用对端"的薄包装，所有业务实现都属于 `core`。

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/README.md
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/README.md
@@ -1,13 +1,98 @@
 # kudos-ms-auth-common
 
-`auth` 原子服务共享契约层。包结构：**`io.kudos.ms.auth.common` 下先按业务模块再分 `api` / `consts` / `enums` / `vo`**；横切内容放在 **`platform`**。
+## 定位
 
-## 模块
+鉴权（`auth`）原子服务的**共享契约层**：不包含持久化、缓存实现或 HTTP 控制器，只提供跨
+`core`、`client`、各 `api-*` 模块复用的 **类型与接口**。依赖面刻意保持精简：仅 `kudos-ms-user-common`
+（用 `UserAccountCacheEntry` 拼装"角色 → 用户"展示信息）与 `spring-web` 的 `compileOnly`
+注解能力（让 Feign 代理识别方法级 `@GetMapping/@PostMapping`），便于其他微服务仅引用本模块即可
+编译通过远程接口与 DTO。
+
+---
+
+## 包结构（`io.kudos.ms.auth.common`）
+
+**第一层按业务模块划分**：
 
 | 模块包 | 内容 |
 |--------|------|
-| `group` | 用户组及组-用户关联等 `vo`、`enums`（原 `groupuser` 已并入） |
-| `role` | `IAuthRoleApi`；角色及角色-资源、角色-用户关联等 `vo`、`enums`（原 `roleresource` / `roleuser` 已并入） |
-| `platform` | `IPermittedResource`（`platform.api`）等跨模块契约 |
+| `group` | 用户组及组-用户、组-角色关联的 `vo` / `enums`（原 `groupuser` / `grouprole` 已并入） |
+| `role`  | 角色契约与 `vo` / `enums`（原 `roleresource` / `roleuser` 已并入） |
+| `platform` | 跨模块横切契约 |
 
-路径示例：`io.kudos.ms.auth.common.role.api`、`io.kudos.ms.auth.common.group.vo`。
+**第二层**按类型分子包（若模块暂无该类内容则省略目录）：
+
+| 子包 | 内容 |
+|------|------|
+| `api` | 该模块对应的 `IAuth*Api` 契约（若有） |
+| `enums` | 错误码枚举 `*ErrorCodeEnum` |
+| `vo` | 值对象：`vo/request`、`vo/response`，及根下的 `*CacheEntry` |
+
+路径示例：`io.kudos.ms.auth.common.role.api`、`io.kudos.ms.auth.common.group.vo.response`。
+
+---
+
+## 接口一览
+
+本模块当前仅暴露一个领域 `Api` 与一个 platform 契约——**`group` 不对外开放 Feign 接口，由
+`auth-api-admin` 直接调用 core Service**：
+
+| 接口 | 包 | 职责概要 |
+|------|----|----------|
+| `IAuthRoleApi` | `role.api` | 角色 / 角色-用户 / 角色-资源 全部对外能力（按 id / code 查、用户↔角色绑定、角色↔资源绑定、`hasRole`、`getUserResourceIds` 等） |
+| `IPermittedResource` | `platform.api` | "当前登录用户可访问资源"——返回菜单树，封装"用户 → 组 → 角色 → 资源"的完整链路 |
+
+> **方法级路由约定**：与 `kudos-ms-sys-common` / `kudos-ms-user-common` 同模式——`IAuth*Api`
+> 在**方法级**挂 `@GetMapping("/api/internal/auth/...")`，**不**在接口类型上放 `@RequestMapping`；
+> 这样 Feign 代理与服务端 Controller 共享同一份路径定义，签名漂移可在编译期暴露。
+
+---
+
+## VO 命名约定
+
+| 后缀 | 用途 |
+|------|------|
+| `*Row` | 列表/表格行（紧凑投影） |
+| `*Detail` | 只读详情（含关联展开，如 `AuthRoleUserDetail` / `AuthRoleResourceDetail`） |
+| `*Edit` | 表单回填 |
+| `*CacheEntry` | 缓存条目（与 core 多级缓存 1:1 对齐） |
+| `*FormCreate` / `*FormUpdate` | 写入入参 |
+| `I*FormBase` | Create / Update 表单共享字段的 Kotlin 接口 |
+| `*Query` | 列表筛选入参 |
+
+`role/vo` 与 `group/vo` 各自包含完整的一套（Row / Detail / Edit / CacheEntry / FormCreate /
+FormUpdate / Query），关系型 VO（`AuthRoleUserDetail` / `AuthRoleResourceDetail` /
+`AuthGroupUserDetail`）放在主资源模块的 `vo/response` 下，**不**单独建 `roleuser` / `groupuser`
+子包。
+
+---
+
+## 依赖关系
+
+- **直接依赖**：`kudos-ms-user-common`（仅为引用 `UserAccountCacheEntry`，让"角色 → 用户"
+  展示链路可在契约层直接表达，避免回环依赖）。
+- **`compileOnly`**：`spring-web`（方法级 Feign 路由注解）。
+- **被依赖方**：`kudos-ms-auth-core`、`kudos-ms-auth-client`；其他微服务也可仅依赖本模块即可
+  使用 `IAuthRoleApi` 与全套 VO。
+
+---
+
+## 与其他子模块的关系
+
+| 模块 | 关系 |
+|------|------|
+| **core** | 实现 `IAuthRoleApi` / `IPermittedResource`，并大量使用本模块的 `vo` / `enums` |
+| **client** | `IAuth*Proxy : IAuth*Api`，序列化同一套 VO |
+| **api-admin** | Controller 入参 / 出参直接使用本模块 VO |
+| **api-internal** | Controller `implements IAuth*Api`，路径完全继承自接口方法级注解 |
+
+---
+
+## 扩展建议
+
+- 新增契约：在对应业务模块下扩展 **`api` / `vo` / `enums`**；若属于横切能力（如另一种
+  "当前用户视图"），再考虑放入 **`platform`**。
+- 若 `group` 后续需要对外暴露 Feign 接口，按 `role` 的形式补 `group.api.IAuthGroupApi`，
+  并在 `auth-client` / `auth-api-internal` 同步加 Proxy / Controller。
+- 保持本模块**无数据库类型与 Spring 运行期注解**——除已存在的方法级路由 `compileOnly`
+  外，不应引入 `@Component` / `@Service` / Jackson 配置等。

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/README.md
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/README.md
@@ -107,3 +107,14 @@ io.kudos.ms.auth.core
 - `kudos-ability-data-rdb-ktorm` / `kudos-ability-cache-common`
 - `kudos-ms-sys-client` / `kudos-ms-user-client`（跨服务查询）
 - `kudos-ability-data-audit`（事件机制基座）
+
+## Kotlin 风格
+
+- **一律 `open class` + Spring CGLIB 代理**——`@Transactional` / `@Cacheable` / `@TransactionalEventListener`
+  切面都要求方法 `open`。`AuthRoleService` / `AuthGroupService` / `*RelationsService` 全部 `open class`。
+- **DAO 通过 ctor 注入；Service 大部分通过 `@Resource` 注入**避免循环依赖——`AuthRoleService` 单类
+  就 7+ 个 `@Resource` 字段（cache / 同域 service / 跨服务 client / 事件发布器互引时很常见）。
+- **Cache 类用 `getSelf<XxxCache>()` 拿 Spring 代理对象**——让 `@Cacheable` 在 `doReload` 等同类内部
+  调用也能生效（绕开 self-invocation 不走代理的 Spring 限制）。本模块所有"key/value 聚合缓存"
+  （`RoleIdsByUserIdCache` / `UserIdsByRoleIdCache` / `UserIdsByTenantIdAndRoleCodeCache` /
+  `UserIdsByGroupIdCache` / `GroupIdsByUserIdCache` 等）都遵循该模式。

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-sql/README.md
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-sql/README.md
@@ -1,24 +1,80 @@
 # kudos-ms-auth-sql
 
-Auth 原子服务的 Flyway 迁移脚本——只放 `*.sql`，无 Kotlin 代码。
+## 定位
 
-## 表结构
+鉴权（`auth`）原子服务的**数据库迁移脚本模块**：仅包含 Flyway 使用的**版本化 SQL 资源**，
+不含 Kotlin 源码。`kudos-ms-auth-core` 通过依赖本模块在运行时加载迁移（与
+`kudos-ability-data-rdb-flyway` 等能力配合）。
 
-| 表 | 说明 |
-|---|---|
-| `auth_role` | 角色主数据 |
-| `auth_role_resource` | 角色 ↔ 资源关联（资源 id 指向 `sys.sys_resource`） |
-| `auth_role_user` | 角色 ↔ 用户关联（用户 id 指向 `user.sys_user`） |
-| `auth_group` | 用户组主数据，带 path 字段表层级 |
-| `auth_group_user` | 组 ↔ 用户关联 |
+本模块 **Gradle 依赖为空**，职责单一，便于单独审阅 schema 变更与版本演进。
 
-## 约定
+---
 
-- 表前缀 `auth_`——与 sys / user / msg 服务隔离
-- Flyway baseline + V_*_* 命名风格
-- 一个 SQL 文件一条迁移；不在一个文件里混多个 DDL/DML
-- 内置数据（如系统角色）走 `R_*` 可重复脚本
+## 资源布局
 
-## 依赖
+脚本位于：
 
-无 Kotlin 依赖，纯资源模块。`auth-core` 在测试 / 部署时引入本模块的 SQL 给 Flyway 跑。
+```
+resources/sql/auth/h2/
+```
+
+> 目录名为 `h2`，与测试 / 本地常用 H2 方言一致；若生产使用其他数据库，可能另有同结构的方言
+> 适配脚本（以本仓库实际目录为准）。
+
+---
+
+## 迁移文件清单
+
+迁移分两段：**`V1.0.0.0`–`V1.0.0.6`** 是写入 `sys` 库的**鉴权域种子数据**（菜单、字典、参数、
+缓存配置、i18n 文案等——这些表的 DDL 属于 `kudos-ms-sys-sql`，本模块只负责"auth 模块占用的
+那批行"），**`V1.0.0.20+`** 才是 auth 自有表的 DDL：
+
+| 迁移文件 | 概要 |
+|----------|------|
+| `V1.0.0.0__insert_sys_micro_service.sql` | 在 `sys_micro_service` 中注册 auth 微服务条目 |
+| `V1.0.0.1__insert_sys_dict.sql` | 注册 auth 模块需要的字典头 |
+| `V1.0.0.2__insert_sys_dict_item.sql` | 上述字典头的项 |
+| `V1.0.0.3__insert_sys_cache.sql` | 在 `sys_cache` 中登记 auth 各级缓存（与 core 的 HashCache / KeyValueCache 1:1 对齐） |
+| `V1.0.0.4__insert_sys_resource.sql` | 注册 auth 管理后台菜单 / 按钮资源 |
+| `V1.0.0.5__insert_sys_param.sql` | 注册 auth 模块的系统参数 |
+| `V1.0.0.6__insert_sys_i18n.sql` | 注册 auth 模块的 i18n 多语言文案 |
+| `V1.0.0.20__init_auth_role.sql` | 角色主表 |
+| `V1.0.0.21__init_auth_role_user.sql` | 角色 ↔ 用户关联（用户 id 指向 `user.sys_user`） |
+| `V1.0.0.22__init_auth_role_resource.sql` | 角色 ↔ 资源关联（资源 id 指向 `sys.sys_resource`） |
+| `V1.0.0.23__init_auth_group.sql` | 用户组主表，含层级 `path` 字段 |
+| `V1.0.0.24__init_auth_group_user.sql` | 组 ↔ 用户关联 |
+| `V1.0.0.25__init_auth_group_role.sql` | 组 ↔ 角色关联（"组里所有人"自动持有该角色） |
+
+> **版本号分段约定**：`V1.0.0.0` 起步号段留给"种子 / 引导"型脚本，业务表 DDL 从 `V1.0.0.20`
+> 开始；这样新增 `insert_*` 种子无需挤占表 DDL 段，反之亦然。
+
+---
+
+## 命名与组织约定
+
+- **表前缀 `auth_`**：与 sys / user / msg 服务隔离；同库部署时按前缀也能快速圈定本服务的表。
+- **`V_*_*` 版本化脚本**：一个文件一条迁移；不在一个文件里混多个 DDL/DML。
+- **内置数据（如系统角色 / 默认管理员）走 `R_*` 可重复脚本**：当前仓库中尚无 `R_*`，按
+  约定后续可以补充。
+- **种子数据写入 `sys_*` 表**：跨服务种子由"被写入方负责 DDL，写入方负责 INSERT"——例如
+  `V1.0.0.4__insert_sys_resource.sql` 是 auth 服务向 sys 库注册自己的菜单条目。
+
+---
+
+## 与其他子模块的关系
+
+| 模块 | 关系 |
+|------|------|
+| **kudos-ms-auth-core** | 依赖本模块 → 运行迁移并基于表结构实现 DAO / Service |
+| **kudos-ms-auth-common** | 无直接依赖；VO 字段与表列在设计上对应 |
+
+---
+
+## 维护注意
+
+- **新增表或变更列**：新增**更高版本号**的迁移文件，避免修改已发布版本脚本（除非团队约定
+  可重建环境）。
+- **跨服务种子**：写入 `sys_*` 表的 INSERT 必须保证幂等（建议 `INSERT ... ON CONFLICT
+  DO NOTHING` 或先 `DELETE` 再 `INSERT`），否则多次 Flyway 验签会失败。
+- **视图（`v_*`）与业务查询强相关**：本模块当前无视图；若后续加，需同步 `core` 的 DAO /
+  实体与 `common` 的 VO。


### PR DESCRIPTION
…onventions

Bring kudos-ms-auth's per-submodule READMEs up to the same depth as kudos-ms-sys:
- common: full package tree, IAuthRoleApi-only contract surface, VO conventions, method-level Feign routing
- sql: complete migration table (V1.0.0.0–V1.0.0.6 sys seeds + V1.0.0.20–V1.0.0.25 auth DDL)
- api-admin: actual 2 controllers + bind/unbind/list endpoint verb convention + inherited security gaps
- api-public: documents the real PermittedResourceController (current-user view) and why it sits here, not in internal
- api-internal: documents AuthRoleInternalController + Nacos/interservice-provider dep stack
- client: proxy/fallback table (auth-role only today), four-piece extension recipe for new remote capabilities
- core: append Kotlin idioms section (open class + @Resource + getSelf<>()) mirroring sys-core
- root: link all submodule READMEs + add cross-module naming/convention section