### PR TITLE
docs(sys): align all 8 module READMEs with current source — fix api-i…

### DIFF
--- a/kudos-ms/kudos-ms-sys/README.md
+++ b/kudos-ms/kudos-ms-sys/README.md
@@ -6,6 +6,50 @@
 
 ---
 
+## 构建与运行
+
+工程根使用 Gradle Wrapper（`./gradlew`），无需本地装 Gradle。以下命令均在仓库根执行。
+
+### 单模块构建 / 测试
+
+```bash
+# 仅编译某个子模块（不跑测试）
+./gradlew :kudos-ms:kudos-ms-sys:kudos-ms-sys-core:assemble
+
+# 跑某个子模块的测试
+./gradlew :kudos-ms:kudos-ms-sys:kudos-ms-sys-core:test
+./gradlew :kudos-ms:kudos-ms-sys:kudos-ms-sys-api-admin:test
+
+# 跑整个 sys 聚合的测试（依赖会被一并构建）
+./gradlew :kudos-ms:kudos-ms-sys:check
+```
+
+> 单测使用 H2（默认 file 模式 `~/h2/sys`，或 H2 TCP server），`Flyway` 在每次启动时跑全套迁移；**不需要** 本地 Postgres / Redis 即可跑通 `*-core` 与 `*-api-admin` 的测试。
+
+### 启动可执行进程（开发态）
+
+`api-admin` / `api-public` / `api-internal` 各自带 Spring Boot `main`，通常组合启动：
+
+```bash
+# 启动 admin（含 /api/admin/sys/** REST），最常用
+./gradlew :kudos-ms:kudos-ms-sys:kudos-ms-sys-api-admin:bootRun
+
+# 启动 internal（含 /api/internal/sys/** RPC + 需要 Nacos）
+./gradlew :kudos-ms:kudos-ms-sys:kudos-ms-sys-api-internal:bootRun
+
+# 仅 Web 装配（基本不直接用）
+./gradlew :kudos-ms:kudos-ms-sys:kudos-ms-sys-api-public:bootRun
+```
+
+`api-admin` 默认 yml 在 `kudos-ms-sys-api-admin/resources/application.yml`（H2 file + `kudos.ability.cache.enabled=true`）。本地无 Redis 时改为 `false`，否则启动会 `RedisConnectionFailureException`。
+
+### 端口与健康检查
+
+- 端口与 actuator 端点由上层可执行模块（如 `*-api-web` 聚合 jar）的 yml 决定；本仓库内 sys 各模块的 yml 没有显式 `server.port`，默认走 Spring Boot `8080`。
+- 健康检查：`GET /actuator/health`（前提是上层装配了 actuator；`kudos-ability-web-springmvc` 是否默认引入以该模块文档为准）。
+
+---
+
 ## 子模块文档索引
 
 | 子模块 | 说明文档 |
@@ -13,51 +57,75 @@
 | [kudos-ms-sys-common](kudos-ms-sys-common/README.md) | 跨模块共享契约：API 接口、VO、枚举、校验与常量 |
 | [kudos-ms-sys-sql](kudos-ms-sys-sql/README.md) | Flyway 迁移脚本（sys 库表与视图） |
 | [kudos-ms-sys-core](kudos-ms-sys-core/README.md) | DAO、Service、缓存、API 实现与 Spring 扫描入口 |
-| [kudos-ms-sys-api-admin](kudos-ms-sys-api-admin/README.md) | 管理端 REST 控制器（`/api/admin/sys/...`） |
-| [kudos-ms-sys-api-public](kudos-ms-sys-api-public/README.md) | 对外 Web 进程启动入口与自动配置（`sys-api-web`） |
-| [kudos-ms-sys-api-internal](kudos-ms-sys-api-internal/README.md) | 对内 Provider 进程启动入口与自动配置（`sys-api-provider`） |
-| [kudos-ms-sys-client](kudos-ms-sys-client/README.md) | Feign 代理与降级，供其他服务远程调用 sys |
+| [kudos-ms-sys-api-admin](kudos-ms-sys-api-admin/README.md) | 管理端 REST 控制器（`/api/admin/sys/**`），控制台 / 管理网关使用 |
+| [kudos-ms-sys-api-public](kudos-ms-sys-api-public/README.md) | 对外 Web 进程启动入口与自动配置（`sys-api-web`，无业务控制器） |
+| [kudos-ms-sys-api-internal](kudos-ms-sys-api-internal/README.md) | **对内 RPC 控制器（`/api/internal/sys/**`）+ Provider 进程入口**，承接 Feign 客户端调用，附带 Nacos discovery/config 装配 |
+| [kudos-ms-sys-client](kudos-ms-sys-client/README.md) | Feign 代理与降级，供其他服务远程调用 sys；含 `FeignDictItemCodeFinder`（不部署 sys-core 时的字典码校验回退） |
 
 ---
 
-## 依赖关系（概念）
+## 依赖关系与路径暴露（概念）
 
 ```
-                    ┌─────────────────┐
-                    │ kudos-ms-sys-   │
-                    │ common          │
-                    └────────┬────────┘
-                             │
-         ┌───────────────────┼───────────────────┐
-         ▼                   ▼                   │
-┌─────────────────┐  ┌─────────────────┐          │
-│ kudos-ms-sys-   │  │ kudos-ms-sys-   │          │
-│ sql             │  │ client          │          │
-└────────┬────────┘  └────────┬────────┘          │
-         │                    │ only common       │
-         └──────────┬─────────┘                   │
-                    ▼                             │
-            ┌───────────────┐                     │
-            │ kudos-ms-sys- │                     │
-            │ core          │◄────────────────────┘
-            └───────┬───────┘
-                    │
-    ┌───────────────┼───────────────┐
-    ▼               ▼               ▼
-┌────────┐   ┌────────────┐   ┌────────────┐
-│ api-   │   │ api-       │   │ api-       │
-│ admin  │   │ public     │   │ internal   │
-└────────┘   └────────────┘   └────────────┘
+                          ┌─────────────────┐
+                          │ kudos-ms-sys-   │   ← 契约层：ISys*Api（含 /api/internal/sys/** 方法注解）
+                          │ common          │     VO、enums、SysConsts / SysDictTypes
+                          └────────┬────────┘
+                                   │
+                ┌──────────────────┼──────────────────────────────┐
+                ▼                  ▼                              ▼
+       ┌─────────────────┐  ┌─────────────────┐         ┌─────────────────┐
+       │ kudos-ms-sys-   │  │ kudos-ms-sys-   │         │ kudos-ms-sys-   │
+       │ sql             │  │ core            │         │ client          │
+       │ (Flyway scripts)│  │ (DAO/Service/   │         │ (Feign proxies, │
+       └────────┬────────┘  │  Cache/Event/   │         │  fallbacks,     │
+                │           │  @Component Api)│         │  FeignDictItem- │
+                └──────────►│                 │         │  CodeFinder)    │
+                            └────────┬────────┘         └─────────────────┘
+                                     │                          ▲
+                ┌────────────────────┼────────────────────┐     │ HTTP /api/internal/sys/**
+                ▼                    ▼                    ▼     │
+       ┌─────────────────┐  ┌────────────────┐  ┌────────────────┐
+       │ kudos-ms-sys-   │  │ kudos-ms-sys-  │  │ kudos-ms-sys-  │
+       │ api-public      │  │ api-admin      │  │ api-internal   │
+       │ (Web 装配,      │  │ /api/admin/    │  │ /api/internal/ │
+       │  无业务路径)    │  │  sys/** REST   │  │  sys/** RPC    │
+       │                 │  │ (15 controllers)│ │ (18 controllers,│
+       │ Spring Boot     │  │                │  │  + Nacos /     │
+       │ main:           │  │ main:          │  │  interservice  │
+       │ SysApiWebApp    │  │ SysApiAdminApp │  │  cache provider)│
+       └─────────────────┘  └────────────────┘  │ main:          │
+                                                │ SysApiProviderApp│
+                                                └────────────────┘
 ```
 
-- **api-admin / api-public / api-internal** 均依赖 **core**；三者差异主要在 **打包形态与依赖的能力栈**（见各子模块 README）。
-- **client** 仅依赖 **common**（及 Feign 能力），避免把 `core` 打进调用方。
+- **client 仅依赖 common**（及 Feign 能力），避免把 `core` 打进调用方。Feign 代理通过 `/api/internal/sys/**` HTTP 路径调用 **api-internal** 的控制器；后者实现 `common.ISys*Api`，三处共享同一份方法签名。
+- **api-admin / api-public / api-internal** 均依赖 **core**，差异在 **挂载的控制器集** 与 **额外能力栈**：
+  - `api-admin`：管理端 15 个 `*AdminController`（继承 `BaseCrudController`）
+  - `api-public`：仅 Web 装配，无业务控制器
+  - `api-internal`：12 个模块共 18 个 `*InternalController`（实现 `ISys*Api`，路径来自接口方法注解）+ Nacos discovery/config + interservice cache provider
+- **sql → core**：core 的 `api` 依赖 sql 模块只为把 Flyway 资源打进 classpath，迁移在运行时由 `kudos-ability-data-rdb-flyway` 触发。
+
+### 路径双轨制
+
+| 路径前缀 | 模块 | 鉴权预期 | 调用方 |
+|---------|------|---------|--------|
+| `/api/admin/sys/**` | api-admin | 网关 / 外部过滤器（**模块内零 `@PreAuthorize`**） | 控制台 / 管理网关 |
+| `/api/internal/sys/**` | api-internal | 内网可达性约束（同样无 `@PreAuthorize`） | `kudos-ms-sys-client` 的 Feign 代理 |
+
+> `api-internal` 端点在路径注解上仅由 `common.ISys*Api` 接口定义；`api-admin` 路径由控制器自身的 `@RequestMapping` 定义。两条路径**不允许互相借用**，否则 admin / internal 双轨制崩溃。
 
 ---
 
 ## 命名与约定（跨模块）
 
 - **默认子系统编码**：`SysConsts.DEFAULT_SUB_SYSTEM_CODE`（`default-sub-system`），与资源、菜单、访问规则等按子系统维度隔离的数据一致。
-- **领域 API**：`common` 中 `ISys*Api` 由 `core` 中 `Sys*Api` 实现；`client` 中 `ISys*Proxy` 继承同一接口并通过 Feign 调用远程服务。
+- **领域 API 三身一体**：`common` 中 `ISys*Api` 在方法上标注 `@*Mapping("/api/internal/sys/...")`，由 **三处** 同时使用：
+  - `core` 的 `Sys*Api`（`@Component`）—— 同进程注入实现
+  - `api-internal` 的 `Sys*InternalController`（`@RestController`）—— 暴露 HTTP
+  - `client` 的 `ISys*Proxy`（`@FeignClient`）—— 远程调用
 
-具体类名与边界以各子模块源码为准。
+  三者的方法签名、参数顺序、URL 路径在编译期通过同一接口绑定；fallback 是唯一不参与编译对齐的处，新增方法时需手动补 override。
+- **路径前缀双轨制**：管理路径 `/api/admin/sys/**`（仅 `api-admin`） vs 内部 RPC 路径 `/api/internal/sys/**`（仅 `api-internal`，且来自 `common` 接口的方法注解）。这两条路径有不同的鉴权与可达性预期，新增端点时不要混淆。
+- **业务模块清单**（与 `common` / `core` 一级目录对齐）：`accessrule`、`cache`、`datasource`、`dict`、`domain`、`i18n`、`locale`、`microservice`、`outline`、`param`、`resource`、`system`、`tenant`，共 13 个。
+- **包结构对齐原则**：`common` / `core` / `client` / `api-admin` / `api-internal` 在 `<module>/` 一级目录上完全一致，便于跨模块对照阅读。`api-public` 不含业务子目录，只有 `init`。

--- a/kudos-ms/kudos-ms-sys/kudos-ms-sys-api-admin/README.md
+++ b/kudos-ms/kudos-ms-sys/kudos-ms-sys-api-admin/README.md
@@ -21,21 +21,27 @@
 
 ## 控制器一览
 
-| 控制器 | 基础路径（示例） | 职责概要 |
-|--------|------------------|----------|
+| 控制器 | 基础路径 | 职责概要 |
+|--------|----------|----------|
 | `SysTenantAdminController` | `/api/admin/sys/tenant` | 租户 CRUD、按子系统查租户、启用状态等 |
 | `SysSystemAdminController` | `/api/admin/sys/system` | 子系统 |
 | `SysMicroServiceAdminController` | `/api/admin/sys/microService` | 微服务 |
 | `SysResourceAdminController` | `/api/admin/sys/resource` | 资源、菜单树等 |
-| `SysDictAdminController` / `SysDictItemAdminController` | `/api/admin/sys/dict` 等 | 字典与字典项 |
+| `SysDictAdminController` | `/api/admin/sys/dict` | 字典头 |
+| `SysDictItemAdminController` | `/api/admin/sys/dictItem` | 字典项（独立路径，与字典头分开） |
 | `SysParamAdminController` | `/api/admin/sys/param` | 系统参数 |
 | `SysI18NAdminController` | `/api/admin/sys/i18n` | 国际化 |
+| `SysLocaleAdminController` | `/api/admin/sys/locale` | 语言/区域全局字典 |
 | `SysDomainAdminController` | `/api/admin/sys/domain` | 业务域 |
 | `SysDataSourceAdminController` | `/api/admin/sys/dataSource` | 数据源 |
-| `SysCacheAdminController` | `/api/admin/sys/cache` | 缓存配置 |
-| `SysAccessRuleAdminController` / `SysAccessRuleIpAdminController` | `/api/admin/sys/accessRule` 等 | 访问规则及 IP |
+| `SysCacheAdminController` | `/api/admin/sys/cache` | 缓存配置元数据 |
+| `SysOutLineAdminController` | `/api/admin/sys/outLine` | 大纲数据 |
+| `SysAccessRuleAdminController` | `/api/admin/sys/accessRule` | 访问规则 |
+| `SysAccessRuleIpAdminController` | `/api/admin/sys/accessRuleIp` | 访问规则 IP（独立路径） |
 
-具体路径以各 `@RequestMapping` 为准；部分 Controller 在基类路由上还有子路径（如 `getTenantsBySubSystemCode`）。
+路径首段为 `camelCase`（如 `microService`、`dataSource`、`outLine`、`accessRule` / `accessRuleIp`、`dictItem`），与 `api-internal` 的 `/api/internal/sys/<module>` 命名一致。
+
+控制器统一继承自 `kudos-ability-web-springmvc` 中的 `BaseCrudController`（或其变体），开箱获得列表 / 详情 / 新增 / 修改 / 删除 / 批删等通用端点；模块特有动作（如租户的 `getTenantsBySubSystemCode`）以子路径附加。
 
 ---
 
@@ -52,14 +58,18 @@ kudos-ms-sys-api-admin
 
 ## 与 api-public / api-internal 的配合
 
-- **api-admin**：承载 **管理 REST**。
-- **api-public**：通常提供 **对外 Web 进程** 的 `main` 与极薄扫描包；可执行应用往往 **同时依赖 admin + core + public**，从而在网关后对外暴露 `/api/admin/sys/**`。
-- **api-internal**：提供 **对内 Provider** 形态与 Nacos 等栈；是否挂载同一套 Controller 取决于上层聚合模块的依赖组合。
+| 模块 | 路径前缀 | 用途 |
+|------|----------|------|
+| **api-admin** | `/api/admin/sys/**` | 管理端 REST，控制台 / 管理网关使用 |
+| **api-internal** | `/api/internal/sys/**` | 内部 RPC，**Feign 客户端** 与服务网格内部使用；控制器实现 `common.ISys*Api` 接口，复用方法级 `@*Mapping` |
+| **api-public** | （无业务路径） | 仅提供启动入口与 Web 栈装配；本身不挂控制器 |
 
-部署拓扑以实际可执行模块（如 gateway、ams-*-api-web）的 `build.gradle.kts` 为准。
+可执行应用通常 **同时依赖 `api-public` + `api-admin` + `api-internal` + `core`**，从而既对外暴露 `/api/admin/sys/**`，又对内暴露 `/api/internal/sys/**`。部署拓扑（哪个进程挂哪些路径）由具体可执行模块的 `build.gradle.kts` 决定。
 
 ---
 
 ## 扩展建议
 
 - 新增管理接口：优先在 **core** 完成 `ISys*Service` 能力，再在本模块新增 `*AdminController`，保持 VO 仅来自 **common**。
+- **不要**把 `/api/admin/**` 端点放到 `common.ISys*Api` 接口里。`common` 中接口的 `@*Mapping` 仅用于 `/api/internal/**` 路径，是 admin / internal 双轨制的契约边界。
+- 管理路径首段使用 `camelCase`（与现有保持一致），不要混用 `kebab-case` 或 `snake_case`。

--- a/kudos-ms/kudos-ms-sys/kudos-ms-sys-api-internal/README.md
+++ b/kudos-ms/kudos-ms-sys/kudos-ms-sys-api-internal/README.md
@@ -2,7 +2,9 @@
 
 ## 定位
 
-系统（`sys`）原子服务的 **对内服务 Provider 壳层**（历史命名 **sys-api-provider**）：提供 **可独立运行的 Spring Boot 入口** 与 **自动配置**，与 `api-public` 类似 **本模块几乎不包含业务 Controller**，但 **额外引入服务发现、配置中心与跨服务缓存 Provider** 等能力，面向 **集群内部** 调用场景（与其它微服务、注册中心协同）。
+系统（`sys`）原子服务的 **对内 RPC HTTP 暴露层**（历史命名 **sys-api-provider**）：在 `kudos-ms-sys-core` 之上，把 `common` 中所有 `ISys*Api` 接口以 `@RestController` 形态暴露为 **`/api/internal/sys/**`** 路径，专供 **`kudos-ms-sys-client` 的 Feign 代理** 调用，同时承载注册中心、配置中心、跨服务缓存等"集群内部"基础设施。
+
+> 与历史 README 不同：本模块 **包含 18 个内部控制器**，并不是"无 Controller 的空壳"。下方"控制器一览"列出全部实现。
 
 ---
 
@@ -11,9 +13,68 @@
 | 类型 | 类 | 说明 |
 |------|-----|------|
 | 启动类 | `SysApiProviderApplication` | `@EnableKudos`，`main` 启动 Spring Boot |
-| 自动配置 | `SysApiProviderAutoConfiguration` | `@ComponentScan("io.kudos.ms.sys.api.internal")`，组件名 **`kudos-ms-sys-api-internal`** |
+| 自动配置 | `SysApiProviderAutoConfiguration` | `@ComponentScan("io.kudos.ms.sys.api.internal")`，组件名 **`kudos-ms-sys-api-internal`**，由 `IComponentInitializer` 机制装配（非 Spring Boot 原生 SPI） |
 
-当前 `io.kudos.ms.sys.api.internal` 包下仅有 `init`，**无 Controller**；实际 REST 仍由 **`kudos-ms-sys-api-admin`**（若在同一进程引入）或网关路由提供。
+`@ComponentScan` 同时扫描 `init` 与 `controller` 子包；`core` 中各 `Sys*Api`（`@Component`）由 `core` 自身的 `SysAutoConfiguration` 提供，本模块只负责把它们暴露为 HTTP。
+
+---
+
+## 控制器实现模式
+
+`api-internal` 中每个控制器：
+
+1. 标 `@RestController`；
+2. **实现 `common.<module>.api.ISys*Api`** 接口；
+3. 不在类上写 `@RequestMapping` —— 所有路径来自 **接口方法上的 `@GetMapping` / `@PostMapping("/api/internal/sys/...")`**；
+4. 仅做 `core.<module>.api.Sys*Api` 的薄委托，不放业务逻辑。
+
+```kotlin
+// common/.../tenant/api/ISysTenantApi.kt —— 契约（路径在这里）
+interface ISysTenantApi {
+    @GetMapping("/api/internal/sys/tenant/getTenant")
+    fun getTenantFromCache(id: String): SysTenantCacheEntry?
+    // ...
+}
+
+// api-internal/.../tenant/SysTenantInternalController.kt —— HTTP 实现
+@RestController
+class SysTenantInternalController(
+    private val sysTenantApi: SysTenantApi,   // core 的 @Component
+) : ISysTenantApi {
+    override fun getTenantFromCache(id: String) = sysTenantApi.getTenantFromCache(id)
+}
+
+// client/.../tenant/proxy/ISysTenantProxy.kt —— Feign 代理
+@FeignClient(name = "...", fallback = SysTenantFallback::class)
+interface ISysTenantProxy : ISysTenantApi   // 沿用同一份方法 + 注解
+```
+
+**好处**：契约（`common`）、本地实现（`core`）、HTTP 实现（`api-internal`）、远程代理（`client`）四者方法签名物理一致；任一处签名漂移会立即编译失败。
+
+**例外**：批量端点中入参 / 出参含 Kotlin `Pair` 时，Jackson 序列化为对象、Feign 反序列化无法还原 `Pair`，因此本模块的 `SysDictInternalController` 额外提供 `List<List<String>>` 形态的 HTTP 适配端点（路径 `/api/internal/sys/dict/batchGetActiveDictItems` 等），不在 `ISysDictApi` 接口上。其他模块如有同样问题需照此模式补适配端点。
+
+---
+
+## 控制器一览
+
+包结构：`io.kudos.ms.sys.api.internal.controller.<module>.Sys*InternalController`，模块名与 `common` / `core` 一致。
+
+| 模块 | 控制器 | 端点路径前缀 |
+|------|--------|-------------|
+| `tenant` | `SysTenantInternalController`、`SysTenantSystemInternalController`、`SysTenantResourceInternalController`、`SysTenantLocaleInternalController` | `/api/internal/sys/tenant`、`.../tenantSystem`、`.../tenantResource`、`.../tenantLocale` |
+| `system` | `SysSystemInternalController` | `/api/internal/sys/system` |
+| `microservice` | `SysMicroServiceInternalController`、`SysSubSystemMicroServiceInternalController` | `/api/internal/sys/microService`、`.../subSystemMicroService` |
+| `resource` | `SysResourceInternalController` | `/api/internal/sys/resource` |
+| `dict` | `SysDictInternalController` | `/api/internal/sys/dict`（含 Pair 适配端点） |
+| `param` | `SysParamInternalController` | `/api/internal/sys/param` |
+| `i18n` | `SysI18nInternalController` | `/api/internal/sys/i18n` |
+| `domain` | `SysDomainInternalController` | `/api/internal/sys/domain` |
+| `datasource` | `SysDataSourceInternalController` | `/api/internal/sys/dataSource` |
+| `accessrule` | `SysAccessRuleInternalController`、`SysAccessRuleIpInternalController` | `/api/internal/sys/accessRule`、`.../accessRuleIp` |
+| `locale` | `SysLocaleInternalController` | `/api/internal/sys/locale` |
+| `outline` | `SysOutLineInternalController` | `/api/internal/sys/outLine` |
+
+> **缓存配置（`cache` 模块）无 internal 控制器是有意为之**：`common.cache.api.ISysCacheApi` 当前是空接口（没有任何方法），它只作为"未来对外暴露"的占位契约存在——`core.SysCacheApi` / `client.ISysCacheProxy` / `client.SysCacheFallback` 都同样是空壳，仅维持 `@FeignClient` + `fallback` 装配的合法性。`/api/admin/sys/cache` 的 CRUD 才是该模块面向运维 / 控制台的真实接口。后续若要让其他微服务读取缓存配置元数据，需要先在 `ISysCacheApi` 上声明方法+`@*Mapping`，再补 `SysCacheInternalController`。
 
 ---
 
@@ -23,11 +84,11 @@
 
 | 依赖 | 作用 |
 |------|------|
-| `kudos-ability-cache-interservice-provider` | 跨服务缓存的 Provider 侧能力 |
+| `kudos-ability-cache-interservice-provider` | 跨服务缓存的 Provider 侧能力（响应远端 invalidate 事件等） |
 | `kudos-ability-distributed-discovery-nacos` | 服务注册与发现（Nacos） |
 | `kudos-ability-distributed-config-nacos` | 配置中心（Nacos） |
 
-因此 **可执行 fat jar** 若使用本模块作为入口，通常具备 **注册到 Nacos、拉取远程配置、参与服务间缓存协议** 等能力；具体行为以 Kudos 各 ability 模块文档与配置为准。
+因此 **可执行 fat jar** 若使用本模块作为入口，会同时获得：注册到 Nacos、拉取远程配置、参与服务间缓存协议、暴露 `/api/internal/sys/**` 端点 这四项能力。
 
 ---
 
@@ -46,17 +107,28 @@ kudos-ms-sys-api-internal
 
 ---
 
-## 与 api-public 的对比
+## 与 api-public / api-admin 的对比
 
-| 维度 | api-public | api-internal |
-|------|------------|--------------|
-| 典型场景 | 对外 Web、网关后的管理 API | 对内 Provider、注册中心、服务间协作 |
-| Nacos / interservice 缓存 | 不强制 | 依赖中默认引入 |
-| 源码中的 Controller | 无（本仓库现状） | 无（本仓库现状） |
+| 维度 | api-public | api-admin | api-internal |
+|------|------------|-----------|--------------|
+| 主类命名 | `SysApiWebApplication` | `SysApiAdminApplication` | `SysApiProviderApplication` |
+| 路径前缀 | （无控制器） | `/api/admin/sys/**` | `/api/internal/sys/**` |
+| Controller 来源 | 无 | 显式定义 `*AdminController` | 实现 `common.ISys*Api` 接口，路径来自接口方法注解 |
+| 调用方 | 一般作为 Web 入口与 `api-admin` 同进程组合 | 控制台 / 管理网关 | **`kudos-ms-sys-client` 的 Feign 代理**；服务网格内部其他微服务 |
+| 额外分布式能力 | 无 | 无 | Nacos discovery / config + interservice cache provider |
+
+---
+
+## ⚠️ 安全考量
+
+- **零 `@PreAuthorize`**：`/api/internal/sys/**` 端点本身不做鉴权，依赖部署拓扑保证只在 **集群内网 / Service Mesh** 内可达。若 Provider 端口暴露到公网，所有 sys 数据可被未授权枚举（参见 sys-core README 的"已知限制 / 安全考量"段）。
+- **Pair 适配端点的 key 拼接** `${first}|${second}` 是单字节分隔；若入参字段本身含 `|`，会在客户端 / 服务端两侧解出错误的 key，需要时改用 URL-safe 编码。
 
 ---
 
 ## 扩展建议
 
-- 部署为 Provider 节点时，需与 **Feign 客户端**（`kudos-ms-sys-client`）及 **网关路由** 中的服务名、上下文路径保持一致。
-- 纯本地开发若不需要 Nacos，可优先使用 **api-public + api-admin** 组合，避免强依赖注册中心。
+- **新增内部 RPC**：先在 `common.<module>.api.ISys*Api` 上加方法 + `@*Mapping`，再在 `core` 实现，最后在本模块对应 `Sys*InternalController` 中覆盖一个 `override fun` —— 三处签名编译期对齐，无需手写路径。
+- **新增模块**：在 `controller/<新模块>/` 下新建 `Sys*InternalController`，并保证 `core` 中已有对应 `Sys*Api` Bean 注入。`@ComponentScan` 已覆盖整个 `controller` 子树，不需要改装配。
+- **Pair / 不可序列化类型**：尽量避免；如必须使用，按 `SysDictInternalController` 模式提供 HTTP 适配端点，并在 `client` 侧的 fallback / proxy 帮助类（`dict/support/FeignDictItemCodeFinder`）里封装调用。
+- **本地开发不需要 Nacos**：可改用 `api-public + api-admin` 组合（参考各模块 README）；但客户端走 Feign 时仍需 internal 控制器，最低限度需要本模块。

--- a/kudos-ms/kudos-ms-sys/kudos-ms-sys-api-public/README.md
+++ b/kudos-ms/kudos-ms-sys/kudos-ms-sys-api-public/README.md
@@ -32,12 +32,16 @@ kudos-ms-sys-api-public
 
 ---
 
-## 典型使用方式
+## 典型组合
 
-- **单独依赖 public**：得到入口与 `core` 全量 Bean，但 **没有** `/api/admin/sys/**` 控制器，除非 classpath 上另有 `api-admin`。
-- **public + admin**：常见组合，用于对外提供完整系统管理 API。
+| 组合 | 入口主类 | 暴露的路径 | 适用场景 |
+|------|----------|------------|----------|
+| **仅 public** | `SysApiWebApplication` | （无业务路径，只剩 `kudos-ability-web-springmvc` 装配的健康检查等） | 验证 Web 装配；通常不直接用于生产 |
+| **public + admin** | `SysApiWebApplication` | `/api/admin/sys/**` | 对外管理 API（控制台后端） |
+| **public + admin + internal** | 任选一个 application 主类（最终扫描三个模块） | `/api/admin/sys/**` + `/api/internal/sys/**` | 单进程同时承载控制台与 Feign 提供方；不需 Nacos 的本地开发可缺省 internal 中的分布式 ability |
+| **internal 单独** | `SysApiProviderApplication` | `/api/internal/sys/**` | 纯 Provider 节点（生产中通常如此分离） |
 
-具体以团队内 **聚合启动模块**（例如 `*-api-web`）的依赖列表为准。
+> 由于本模块的 `SysApiWebAutoConfiguration` 仅扫描 `io.kudos.ms.sys.api.public`（包内只有 `init`），实际"加载哪些控制器"完全由 classpath 上是否含 `api-admin` / `api-internal` 决定——`core` 的 `SysAutoConfiguration` 在 `IComponentInitializer` 编排下会一并启动。
 
 ---
 
@@ -46,11 +50,14 @@ kudos-ms-sys-api-public
 | 维度 | api-public | api-admin | api-internal |
 |------|------------|-----------|--------------|
 | 主类命名 | `SysApiWebApplication` | `SysApiAdminApplication` | `SysApiProviderApplication` |
-| 是否含 Controller | 否（本仓库现状） | 是 | 否（本仓库现状） |
-| 额外分布式能力 | 无（仅 core + MVC） | 无 | Nacos、interservice 缓存等 |
+| 是否含 Controller | **否** | 是（管理端 REST） | 是（**对内 RPC**，路径继承 `common.ISys*Api` 的方法注解） |
+| 路径前缀 | （无） | `/api/admin/sys/**` | `/api/internal/sys/**` |
+| 额外分布式能力 | 无（仅 core + MVC） | 无 | Nacos discovery / config + interservice 缓存 provider |
+| 典型部署 | 与 admin 同进程作为对外 Web | 单独可执行 | 单独可执行（注册到 Nacos） |
 
 ---
 
 ## 扩展建议
 
-- 若需「纯 Web 网关入口」专用配置，可放在 `io.kudos.ms.sys.api.public` 下并由本模块扫描；**业务接口仍建议放在 api-admin**，便于权限与路由前缀统一。
+- 若需「纯 Web 网关入口」专用配置（如 CORS、全局 filter、统一异常处理装配），可放在 `io.kudos.ms.sys.api.public` 下并由本模块扫描；**业务接口仍建议放在 api-admin / api-internal**，便于权限与路由前缀统一。
+- **不要在本模块加业务 Controller**——一旦 public 自带控制器，"public + admin" 与 "public + internal" 的组合就会暴露不一致的端点集，破坏路径双轨制（`/api/admin/**` vs `/api/internal/**`）的清晰边界。

--- a/kudos-ms/kudos-ms-sys/kudos-ms-sys-client/README.md
+++ b/kudos-ms/kudos-ms-sys/kudos-ms-sys-client/README.md
@@ -10,7 +10,7 @@
 
 ## 包结构
 
-在 **`io.kudos.ms.sys.client.<业务模块>`** 下与 **common/core** 的模块名对齐；每个模块内再分 **`proxy`**（`ISys*Proxy`，Feign）与 **`fallback`**（`Sys*Fallback`）子包。
+在 **`io.kudos.ms.sys.client.<业务模块>`** 下与 **common/core** 的模块名对齐；每个模块内再分 **`proxy`**（`ISys*Proxy`，Feign）与 **`fallback`**（`Sys*Fallback`）子包。少数模块（如 `dict`）额外提供 **`support`** 子包承载客户端侧的辅助逻辑。
 
 典型形态：
 
@@ -22,33 +22,54 @@ interface ISysTenantProxy : ISysTenantApi
 `name` 为注册中心中的 **服务名**（或配置映射名），需与 **提供 sys 能力的进程** 在注册中心中的名称一致。
 
 | Proxy | Feign `name` |
-|-------|----------------|
+|-------|--------------|
 | `ISysTenantProxy` | `sys-tenant` |
+| `ISysTenantSystemProxy` | `sys-tenantsystem` |
+| `ISysTenantResourceProxy` | `sys-tenantresource` |
+| `ISysTenantLocaleProxy` | `sys-tenantlocale` |
 | `ISysSystemProxy` | `sys-system` |
 | `ISysMicroServiceProxy` | `sys-microservice` |
 | `ISysSubSystemMicroServiceProxy` | `sys-subsystemmicroservice` |
 | `ISysResourceProxy` | `sys-resource` |
-| `ISysDictProxy` / `ISysDictItemProxy` | `sys-dict` / `sys-dictitem` |
+| `ISysDictProxy` | `sys-dict` |
+| `ISysDictItemProxy` | `sys-dictitem` |
 | `ISysParamProxy` | `sys-param` |
 | `ISysI18nProxy` | `sys-i18n` |
 | `ISysDomainProxy` | `sys-domain` |
 | `ISysDataSourceProxy` | `sys-datasource` |
 | `ISysCacheProxy` | `sys-cache` |
-| `ISysAccessRuleProxy` / `ISysAccessRuleIpProxy` | `sys-accessrule` / `sys-accessruleip` |
-| `ISysTenantSystemProxy` / `ISysTenantResourceProxy` / `ISysTenantLocaleProxy` | `sys-tenantsystem` / `sys-tenantresource` / `sys-tenantlocale` |
+| `ISysAccessRuleProxy` | `sys-accessrule` |
+| `ISysAccessRuleIpProxy` | `sys-accessruleip` |
+| `ISysLocaleProxy` | `sys-locale` |
+| `ISysOutLineProxy` | `sys-out-line` |
 
-> 若实际部署将多个 API 合并为单一服务名，需在 **Feign 配置或网关** 中做路径/服务映射，上表为代码中的默认 `name`。
+> **服务名命名风格不统一**：多数模块以小写无连字符（`sys-tenantsystem`、`sys-accessruleip`），但 `outline` 用了 `sys-out-line`（含连字符）。这是历史遗留；若调整需同时改 Nacos / 网关路由映射。
 
-**Fallback** 与对应 Proxy 分属同模块下的 **`fallback`** / **`proxy`** 包，在远程调用失败时执行降级逻辑（返回值、空列表或抛业务异常等，以各实现类为准），避免级联故障。
+**Fallback** 与对应 Proxy 分属同模块下的 **`fallback`** / **`proxy`** 包，所有 Fallback 继承自 **`io.kudos.ms.sys.client.support.SysClientFallbackSupport`**——本质是上游 `AbstractFeignFallbackSupport` 的本模块别名，保留它只是为了避免一次性修改 17+ 个已落地 Fallback 的父类；**新模块的 Fallback 可直接继承 `AbstractFeignFallbackSupport`**。
+
+降级语义随业务而定（多为返回空集合 / null / 业务异常），目的是在 sys 不可用时避免级联故障，而不是静默吞错。
 
 ---
 
 ## Gradle 依赖
 
 - **`kudos-ms-sys-common`**：契约与序列化类型。
-- **`kudos-ability-distributed-client-feign`**：Feign 与 Spring Cloud 集成。
+- **`kudos-ability-distributed-client-feign`**：Feign 与 Spring Cloud 集成（含 `AbstractFeignFallbackSupport` 基类）。
 
-测试依赖 **`kudos-test-container`**（以 `build.gradle.kts` 为准）。
+测试依赖 `kudos-test-container`。
+
+---
+
+## 字典码校验：双实现 + ServiceLoader
+
+`common.base` 的 `@DictItemCode` 校验通过 `ServiceLoader` 寻找 **`IDictItemCodeFinder`** 实现：
+
+| 实现 | 模块 | 路径 |
+|------|------|------|
+| `DictItemCodeFinder` | `kudos-ms-sys-core` | 本进程查 Hash 缓存（部署 sys 的服务） |
+| `FeignDictItemCodeFinder` | 本模块 `dict/support/` | 通过 `ISysDictProxy` 远程取（**不部署 sys-core 的下游服务**） |
+
+本模块 `resources/META-INF/services/io.kudos.base.bean.validation.terminal.convert.converter.IDictItemCodeFinder` 注册了 `FeignDictItemCodeFinder`。两者在同一 deployment 通常只命中一个：sys 提供方依赖 `core`、下游服务依赖 `client`，**不会同时上线**。该实现通过 `SpringKit.getBean` 在首次校验时 lazy 取 `ISysDictProxy`，因此可以在不修改使用方代码的前提下，让没有 sys-core 的服务继续走字典码校验。
 
 ---
 
@@ -65,8 +86,15 @@ interface ISysTenantProxy : ISysTenantApi
 ## 使用注意
 
 1. **启用 Feign 扫描**：调用方 Spring Boot 应用需能扫描到 `io.kudos.ms.sys.client`（含各模块下的 `proxy`；或通过 `@EnableFeignClients` 指定 basePackages）。
-2. **服务发现**：`name` 需与 Nacos/Eureka 等中的实例一致；本地开发可用固定 URL 配置（视 Spring Cloud 版本而定）。
-3. **契约变更**：修改 `ISys*Api` 时须同步检查 **core 实现**、**fallback** 与 **服务端 Controller**（若有 HTTP 对齐），避免 Feign 与实现脱节。
+2. **服务发现**：`name` 需与 Nacos / Eureka 等中的实例一致；本地开发可用固定 URL 配置（视 Spring Cloud 版本而定）。
+3. **契约变更**：修改 `common.ISys*Api` 时四处必须同步：
+   - `core` 中 `Sys*Api`（同进程实现）
+   - `api-internal` 中 `Sys*InternalController`（HTTP 暴露）
+   - 本模块 `Sys*Proxy`（自动继承，不用手动改）
+   - 本模块 `Sys*Fallback`（需手动补 override）
+
+   前三处由编译期强制对齐，**fallback 是唯一可能漏改的地方**——新增方法时 IDE 不会报错，但运行期一旦走降级就会用到默认行为。建议每次给 `ISys*Api` 加方法时连带过一遍对应 fallback。
+4. **`Pair` 入参的批量端点**：直接调 `ISysDictProxy.batchGetActiveDictItems(...)`（Pair 版）不可行——Jackson 序列化 `Pair` 后远端无法反序列化。应改调 `SysDictInternalController` 提供的 `batchGetActiveDictItemsHttp`（`List<List<String>>` 版），或在调用方做包装。当前 client 模块未为该适配端点提供 proxy 方法，使用方需要自行调用。
 
 ---
 

--- a/kudos-ms/kudos-ms-sys/kudos-ms-sys-common/README.md
+++ b/kudos-ms/kudos-ms-sys/kudos-ms-sys-common/README.md
@@ -10,9 +10,9 @@
 
 **第一层按业务模块划分**，模块名与历史 `vo` 下的一级目录一致：
 
-`accessrule`、`cache`、`datasource`、`dict`、`domain`、`i18n`、`microservice`、`param`、`resource`、`system`、`tenant`
+`accessrule`、`cache`、`datasource`、`dict`、`domain`、`i18n`、`locale`、`microservice`、`outline`、`param`、`resource`、`system`、`tenant`
 
-**字典头** 与 **字典项** 同属 **`dict`**：`ISysDictApi` / `ISysDictItemApi` 均在 **`dict.api`**；相关 VO 在 **`dict.vo`**（含 `SysDictItem*` 等），**无** `dictitem` 子包。**访问规则 IP** 与主规则同属 **`accessrule`**（`accessrule.api` / `accessrule.vo`），**无** `accessruleip` 子包。
+**字典头** 与 **字典项** 同属 **`dict`**：`ISysDictApi` / `ISysDictItemApi` 均在 **`dict.api`**；相关 VO 在 **`dict.vo`**（含 `SysDictItem*` 等），**无** `dictitem` 子包。**访问规则 IP** 与主规则同属 **`accessrule`**（`accessrule.api` / `accessrule.vo`），**无** `accessruleip` 子包。**租户语言**（`SysTenantLocaleApi`）和**语言/区域主数据**（`SysLocaleApi`）是 **两个独立模块**：前者属 `tenant`（租户与语言的绑定），后者属 `locale`（全局语言字典）。
 
 **第二层**在各模块下按类型分为四类子包（若该模块暂无某类内容可省略目录）：
 
@@ -23,12 +23,13 @@
 | **`enums`** | 错误码枚举 `*ErrorCodeEnum`、领域枚举（如 `ResourceTypeEnum`）等 |
 | **`vo`** | 值对象：`vo/request`、`vo/response` 及根下的 `*CacheEntry` 等 |
 
-**跨模块、不属于单一业务域**的契约放在 **`io.kudos.ms.sys.common.platform`** 下，同样按类型分子包：
+**跨模块、不属于单一业务域**的契约放在 **`io.kudos.ms.sys.common.platform`** 下：
 
 | 子包 | 说明 |
 |------|------|
-| **`platform.consts`** | 全局常量，如 **`SysConsts`**、**`SysDictTypes`** |
-| **`platform.validation`** | 跨模块校验器，如 **`DictCodeValidator`** 及 **`DictCodeConstraintValidatorProvider`** |
+| **`platform.consts`** | 全局常量，如 **`SysConsts`**（含 `ATOMIC_SERVICE_NAME = "sys"`、`DEFAULT_SUB_SYSTEM_CODE`）、**`SysDictTypes`**（启动期由 `core.dict.support.SysDictTypesStartupValidator` 校验真实存在） |
+
+> 早期版本另含 `platform.validation`（`DictCodeValidator` 等）。当前实现将字典编码校验下沉到 `core.dict.support`，`common` 不再承载校验逻辑，仅保留常量契约。
 
 示例（租户模块）：
 
@@ -46,17 +47,26 @@
 
 | 接口 | 模块包 | 职责概要 |
 |------|--------|----------|
-| `ISysTenantApi` 等 | `tenant.api` | 租户及租户-子系统/资源/语言 |
+| `ISysTenantApi`、`ISysTenantSystemApi`、`ISysTenantResourceApi`、`ISysTenantLocaleApi` | `tenant.api` | 租户及租户-子系统 / 资源 / 语言绑定 |
 | `ISysSystemApi` | `system.api` | 子系统 |
 | `ISysMicroServiceApi`、`ISysSubSystemMicroServiceApi` | `microservice.api` | 微服务及子系统-微服务绑定 |
-| `ISysResourceApi` | `resource.api` | 资源/菜单树 |
+| `ISysResourceApi` | `resource.api` | 资源 / 菜单树 |
 | `ISysDictApi` / `ISysDictItemApi` | `dict.api`（并列两个接口） | 字典与字典项 |
 | `ISysParamApi` | `param.api` | 系统参数 |
-| `ISysI18nApi` | `i18n.api` | 国际化 |
+| `ISysI18nApi` | `i18n.api` | 国际化（实现侧类名为 `SysI18NService` 的历史命名仍保留） |
 | `ISysDomainApi` | `domain.api` | 业务域 |
 | `ISysDataSourceApi` | `datasource.api` | 数据源 |
-| `ISysCacheApi` | `cache.api` | 缓存配置元数据 |
+| `ISysCacheApi` | `cache.api` | 缓存配置元数据（**当前空接口**：保留作为契约占位，运维 / 控制台读写走 `api-admin` 下的 `/api/admin/sys/cache`，没有 internal RPC 端点；新增 RPC 方法前对应的 `Sys*InternalController` 也未生成） |
 | `ISysAccessRuleApi` / `ISysAccessRuleIpApi` | `accessrule.api`（并列两个接口） | 访问规则及 IP |
+| `ISysLocaleApi` | `locale.api` | 语言/区域全局字典（与 `tenant.SysTenantLocaleApi` 配合使用） |
+| `ISysOutLineApi` | `outline.api` | 大纲数据，按 (子系统, 租户) 缓存 |
+
+每个 `ISys*Api` 方法上以 `@GetMapping` / `@PostMapping` 标注 **`/api/internal/sys/...`** 路径——同一个接口同时承担：
+1. **同进程注入**：`core` 中 `Sys*Api`（`@Component`）实现该接口；
+2. **Feign 远程调用**：`client` 中 `ISys*Proxy : ISys*Api` 沿用方法签名与路径；
+3. **HTTP 暴露**：`api-internal` 中 `Sys*InternalController` 实现该接口，由 Spring MVC 根据方法级注解暴露同一 `/api/internal/sys/...` 路径。
+
+三者共享同一份方法签名，是 sys 服务"本地 / 远程 / HTTP 一致性"的关键。
 
 ---
 
@@ -89,4 +99,5 @@
 ## 扩展建议
 
 - 新增契约：在对应业务模块下增加或扩展 **`api` / `vo` / `enums`**；若确属横切能力，再考虑放入 **`platform`**。
-- 保持本模块**无数据库类型**；与校验、Spring 相关的少数类以现有 `platform` 为准。
+- 保持本模块**无数据库类型**、无 ORM / Ktorm 依赖。`api` 接口仅依赖 `kudos-context`、Spring Web 注解与少量基础类型。
+- 新增 `ISys*Api` 方法时，**必须** 标注 `@GetMapping` / `@PostMapping("/api/internal/sys/<module>/<methodName>")` —— `api-internal` 控制器仅依靠这些注解暴露 HTTP，Feign 客户端也依靠它们路由。漏标的方法在 `client` 一侧会直接 404。

--- a/kudos-ms/kudos-ms-sys/kudos-ms-sys-core/README.md
+++ b/kudos-ms/kudos-ms-sys/kudos-ms-sys-core/README.md
@@ -2,9 +2,9 @@
 
 ## 定位
 
-系统（`sys`）原子服务的 **领域实现中心**：在 `kudos-ms-sys-common` 契约与 `kudos-ms-sys-sql` 表结构之上，提供 **Ktorm 数据访问、业务服务、多级缓存、以及 `ISys*Api` 的 Spring 实现**。不包含 HTTP 控制器（控制器在 `kudos-ms-sys-api-admin`）。
+系统（`sys`）原子服务的 **领域实现中心**：在 `kudos-ms-sys-common` 契约与 `kudos-ms-sys-sql` 表结构之上，提供 **Ktorm 数据访问、业务服务、多级缓存、领域事件、以及 `ISys*Api` 的 Spring 实现**。本模块不包含 HTTP 控制器——管理控制器在 `kudos-ms-sys-api-admin`，对内 RPC 控制器在 `kudos-ms-sys-api-internal`。
 
-`core` **不按** `vo` 同名建包，业务能力分布在 `model` / `dao` / `service` / `cache` / `api` 等通用分层中；下表按 **`kudos-ms-sys-common` 中 `io.kudos.ms.sys.common.<模块>` 的业务模块名**归纳各块在 `core` 中的职责（与 `ISys*Api`、`Sys*Service`、`Sys*Dao`、`*HashCache` 等对应）。**字典项** 的契约与 VO 已在 **`common.dict`** 的 `api` / `vo` 叶子包（与字典头同模块），**无** `dictitem` 子包；**规则 IP** 同理在 **`common.accessrule`**，**无** `accessruleip` 子包；实现侧在 **`core.dict`** / **`core.accessrule`** 下同层。
+**包结构与 `common` 对齐**：`core` 同样以业务模块为一级目录（`io.kudos.ms.sys.core.<module>`），每个模块内再按分层分子包 `model/`（`table`、`po`）、`dao/`、`service/`（`iservice` + `impl`）、`cache/`、`api/`、`event/`、可选 `support/`。这是历史 README 描述的 "flat 分层" 的实际形态——不是 `core.dao.SysXxxDao` 而是 **`core.<module>.dao.SysXxxDao`**。**字典项** 的契约与 VO 已在 **`common.dict`** 的 `api` / `vo` 叶子包（与字典头同模块），**无** `dictitem` 子包；**规则 IP** 同理在 **`common.accessrule`**，**无** `accessruleip` 子包；实现侧在 **`core.dict`** / **`core.accessrule`** 下同层。
 
 ---
 
@@ -18,7 +18,9 @@
 | **dict** | **字典头与字典项**：字典类型（头）的树形结构、编码约束；**字典项**挂接在头下，配合项编码解析。对应 `SysDict*`、`SysDictItem*`、`VSysDictItem*` 视图服务、`SysDictHashCache`、`SysDictItemHashCache`、`SysDictApi`、`SysDictItemApi`，以及 `DictItemCodeFinder` 等支撑。 |
 | **domain** | 业务域（`SysDomain`）：用于域隔离、路由或切换上下文的领域标识；对应 `SysDomain*`、`DomainByNameCache`、`SysDomainApi`。 |
 | **i18n** | 国际化键值与多语言文案：按原子服务/命名空间等维度管理；对应 `SysI18n*`（实现中多为 `SysI18NService` 命名）、`SysI18nHashCache`、`SysI18nApi`。 |
+| **locale** | **语言/区域全局字典**：维护 locale code（如 `zh_CN`）及显示名称；`LocaleByCodeCache` 按 code 单 key 缓存；对应 `SysLocale*` DAO / Service / Api，由 V1.0.0.23 表 + V1.0.0.24 seed 提供数据兜底。**与 `tenant.SysTenantLocale*`（租户↔语言绑定）配合使用，不是同一概念。** |
 | **microservice** | 平台注册的微服务元数据（编码、名称等）：对应 `SysMicroService*`、`SysMicroServiceHashCache`、`SysMicroServiceApi`。子系统与微服务的 **绑定关系** 在表结构中单立，由 `SysSubSystemMicroService*` Service/API 实现（契约见 `ISysSubSystemMicroServiceApi`，无独立 `vo` 子包时仍属本能力块）。 |
+| **outline** | **大纲（OutLine）**：按 (子系统编码, 租户 ID) 复合键缓存的轮廓数据；键归一化由 `OutLineSystemTenantKey` 统一，缓存为 `OutLineBySystemAndTenantCache`，对应 `SysOutLineDao` / `SysOutLineApi`；数据来源 V1.0.0.22 表 + V1.0.0.25 seed。 |
 | **param** | 系统/模块级参数键值：按模块名与参数名定位；对应 `SysParam*`、`ParamByModuleAndNameCache`、`SysParamApi`。 |
 | **resource** | 资源与菜单树（含 URL、类型、图标、层级）：支撑控制台路由与权限资源模型；对应 `SysResource*`、`SysResourceHashCache`、`SysResourceApi`（含菜单树构建等）。 |
 | **system** | **子系统**（subsystem / system）主数据：与租户、资源、访问规则等按 `subSystemCode` 关联；对应 `SysSystem*`、`SysSystemHashCache`、`SysSystemApi`。 |
@@ -28,53 +30,35 @@
 
 ## 架构分层
 
-### `io.kudos.ms.sys.core.init`
+> **实际包结构是按业务模块分的，不是按层分的**：`core.<module>.<layer>`。下文按 **分层** 描述每层应有的子包，但物理上每层都散落在各 `<module>/` 子目录里。
 
-- **`SysAutoConfiguration`**  
-  - `@Configuration` + `@ComponentScan("io.kudos.ms.sys.core")`  
-  - `@AutoConfigureAfter(KtormAutoConfiguration::class)`，保证数据源与 Ktorm 就绪后再装配本域 Bean。  
-  - 实现 `IComponentInitializer`，组件名为 **`kudos-ms-sys-core`**，供 Kudos 统一启动编排识别。
+### 横切层：`io.kudos.ms.sys.core.platform`
 
-### `io.kudos.ms.sys.core.model`
+承载非领域专属的"原子服务级"装配与工具，是其它分层的依赖前提。
 
 | 子包 | 内容 |
 |------|------|
-| `table` | Ktorm 表对象（如 `SysSystems`、`SysTenants`、`SysResources` 等） |
-| `po` | 持久化实体 / 行对象（与表或视图对应） |
+| `platform.init` | **`SysAutoConfiguration`**：`@Configuration` + `@ComponentScan("io.kudos.ms.sys.core")`，`@AutoConfigureAfter(KtormAutoConfiguration::class)`；实现 `IComponentInitializer`，组件名 `kudos-ms-sys-core`，参与 Kudos 启动编排（不依赖 Spring Boot 原生 `META-INF/spring.factories`）。详见 [project_autoconfig_spi](../../../.claude/memory/project_autoconfig_spi.md) 描述的 IComponentInitializer 机制。 |
+| `platform.cache` | **`CacheConfigProvider`**：领域缓存的容量 / TTL 集中配置入口。 |
+| `platform.service.impl` | **`CrudLogSyncSupport`** 等横切工具：审计日志钩子，被各业务 Service 选择性调用。 |
 
-### `io.kudos.ms.sys.core.dao`
+### 业务模块层：`io.kudos.ms.sys.core.<module>`
 
-数据访问对象，与表一一对应，例如：`SysTenantDao`、`SysResourceDao`、`SysDictDao`、`SysAccessRuleDao`、`VSysAccessRuleWithIpDao`（视图查询）等。复杂列表/条件查询在 Service 层组合。
+每个业务模块（见上表 13 项）内部统一以下子包（按需出现）：
 
-### `io.kudos.ms.sys.core.service`
+| 子包 | 内容 | 典型类型 |
+|------|------|---------|
+| `model.table` | Ktorm `Table<*>` / `BaseTable<*>` 表对象 | `SysTenants`、`SysResources`、`VSysDictItems`（视图也在此层） |
+| `model.po` | 持久化 / 视图行对象 | `SysTenant`、`VSysDictItem` |
+| `dao` | Ktorm DAO；与表一一对应（含视图 DAO 前缀 `VSys*`） | `SysTenantDao`、`VSysAccessRuleWithIpDao` |
+| `service.iservice` | 服务接口 | `ISysTenantService`、`IVSysAccessRuleIpService` |
+| `service.impl` | 业务实现（`open class`，参见下文 Kotlin 风格） | `SysTenantServiceImpl` |
+| `cache` | 领域缓存处理器（多级 Caffeine + Redis），与 Service 通过事件解耦 | `TenantByIdCache`、`SysDictHashCache`、`LocaleByCodeCache`、`OutLineBySystemAndTenantCache`、`AccessRuleIpsBySubSysAndTenantIdCache` |
+| `event` | 领域事件定义（`Sys*Inserted/Updated/Deleted/BatchDeleted`），供 `cache` 层用 `@TransactionalEventListener(AFTER_COMMIT)` 订阅 | `TenantEvents.kt`、`AccessRuleIpEvents.kt`、`DictEvents.kt`、`DictItemEvents.kt`（同一模块可拆多个事件文件） |
+| `api` | `@Component` 形态的 `Sys*Api`，实现 `common` 中 `ISys*Api`，方法签名与路径与接口完全一致，供 **同进程注入** 与 **`api-internal` 控制器复用** | `SysTenantApi`、`SysOutLineApi` |
+| `support`（可选） | 模块内辅助类，避免 Service 膨胀 | `dict/support/DictItemCodeFinder`、`dict/support/SysDictTypesStartupValidator`（启动期校验 `SysDictTypes` 声明的字典都真实存在） |
 
-| 子包 | 内容 |
-|------|------|
-| `iservice` | 服务接口（`ISys*Service` 及只读/视图专用接口如 `IVSysAccessRuleIpService`） |
-| `impl` | 业务实现：租户、资源、字典、参数、I18N、数据源、域、缓存、微服务、子系统绑定、访问规则与 IP、租户扩展（资源/语言/子系统关系）等 |
-
-部分实现依赖 **本地 Caffeine + 远程 Redis** 缓存能力（见 `build.gradle.kts`），与 `cache` 包协同。
-
-### `io.kudos.ms.sys.core.cache`
-
-> 注意：此处 `core.cache` 指 **缓存基础设施与领域缓存处理器**；与上表中 **`vo.cache` 所指的「缓存配置」业务表**（`SysCache*`）不是同一概念。
-
-领域缓存的 **装载与一致性** 逻辑，例如：
-
-- `SysResourceHashCache`、`SysTenantSystemHashCache`、`TenantByIdCache`
-- `SysDictHashCache`、`SysDictItemHashCache`、`SysI18nHashCache`
-- `ParamByModuleAndNameCache`、`DomainByNameCache`、`SysCacheHashCache`
-- `AccessRuleIpsBySubSysAndTenantIdCache` 等
-
-与 Service 配合，在增删改后同步或失效缓存。
-
-### `io.kudos.ms.sys.core.api`
-
-- **`Sys*Api`**（`@Component`）：实现 `common` 中对应的 **`ISys*Api`**，委托给相应 `ISys*Service`，供 **同进程内** 其他 Bean 直接注入调用（与 Feign 远程调用并存）。
-
-### `io.kudos.ms.sys.core.support`
-
-- 如 **`DictItemCodeFinder`** 等辅助逻辑，减轻 Service 重复代码。
+> **`core.cache` 不存在为顶层基础设施目录**——`cache` 仅作为各业务模块的子包出现。`common.cache` 模块对应的是"缓存配置元数据"业务表（`SysCache*`），与缓存基础设施名字撞车但是两回事。
 
 ---
 
@@ -96,7 +80,31 @@
 ## 测试
 
 - 源码测试位于 `test-src`，测试数据 SQL 位于 **`test-resources/sql/h2/<业务模块>/<分层>/`**：`<业务模块>` 与 `core` / `common` 中的模块名对齐（如 `dict`、`accessrule`、`tenant`；**缓存配置** 元数据相关为 `sys_cache`）；`<分层>` 为 `cache`、`dao`、`service` 之一，文件名为对应 `*Test.sql`（与测试类名一致）。`SqlTestBase` 会在 `sql/h2` 下递归解析。
-- 覆盖缓存、DAO、Service 等（以仓库内实际测试类为准）。
+- 覆盖范围：每个 `cache` / `dao` / `service` 实现类应有对应 `*Test`，新增类应连带补测试 SQL fixture。
+- **测试不 mock 数据库**——使用真实 H2 + Flyway 跑全套迁移；这是项目级原则。
+
+---
+
+## 配置键速查
+
+`core` 模块本身不在 `@Value` / `@ConfigurationProperties` 上声明配置，关键键由依赖的 ability 模块消费。运行 `core` 测试或基于 `core` 启动 sys 进程时，最少要在 `application.yml` 提供：
+
+| 键 | 用途 | 典型值（测试 / 本地） |
+|----|------|---------------------|
+| `spring.datasource.dynamic.primary` | 多数据源默认源名 | `h2`（本地 file） / `h2-tcp`（H2 TCP server） |
+| `spring.datasource.dynamic.datasource.<name>.url/username/password/driver-class-name` | 各数据源连接信息 | `jdbc:h2:~/h2/sys;DATABASE_TO_LOWER=TRUE;` |
+| `spring.datasource.dynamic.hikari.*` | Hikari 连接池调优 | 见 `kudos-ms-sys-api-admin/resources/application.yml` 模板 |
+| `kudos.ability.flyway.datasource-config.sys` | 把 `sys` 库的 Flyway location 绑定到上面哪个数据源名 | `h2` |
+| `kudos.ability.cache.enabled` | 是否启用 Redis 远程缓存；**本地无 Redis 时设为 `false`**，否则启动会 `RedisConnectionFailureException` | `true`（默认） |
+| `logging.level.org.springframework.core.io.support.SpringFactoriesLoader` | 调 `DEBUG` 时能在控制台看到 ability/auto-config 装配链——排查 `IComponentInitializer` 顺序问题时常用 | `DEBUG`（按需） |
+
+**缓存 TTL / 策略不来自 yml**：`core.platform.cache.CacheConfigProvider` 实现 `ICacheConfigProvider`，在 `@DependsOn("dataSource")` 之后从 **`sys_cache` 表** 读取 active 行，按 `strategyDictCode`（`SINGLE_LOCAL` / `REMOTE` / `LOCAL_REMOTE`）+ `hash` 标志分发到各 cache manager。这意味着：
+
+- 调整某个 cache 的容量 / TTL / 是否走 Redis 不需要改代码，改 `/api/admin/sys/cache` 即可；
+- 但 **首次启动**（DB 空表）时 `CacheConfigProvider` 返回空——必须靠 Flyway seed / 运维预置 `sys_cache` 行；
+- 缓存名是 cache 类内部的字符串常量（`CACHE_NAME`），与 `sys_cache.name` 必须一致，否则配置查不到默认走 ability 内置 fallback。
+
+> sys 服务在 Nacos / Spring Cloud 上的具体键（如 `spring.cloud.nacos.discovery.server-addr`）由 `kudos-ability-distributed-discovery-nacos` 定义，详见 `api-internal` 的 ability 依赖文档。
 
 ---
 
@@ -104,8 +112,9 @@
 
 | 模块 | 关系 |
 |------|------|
-| **api-admin** | 注入 `ISys*Service`，暴露 REST |
-| **api-public / api-internal** | 运行时随可执行应用一起加载 `core` 的 Bean |
+| **api-admin** | 注入 `ISys*Service`，暴露 `/api/admin/sys/**` REST |
+| **api-internal** | 注入 `Sys*Api`（`@Component`），通过实现 `ISys*Api` 接口同时复用方法级 `@*Mapping`，把 `/api/internal/sys/**` 暴露给 Feign 客户端 |
+| **api-public** | 仅承载启动入口与 Web 栈装配；运行时随可执行应用一起加载 `core` 的 Bean |
 | **client** | **不**依赖 `core`；远程调用走 Feign，服务端仍由本模块提供实现 |
 
 ---
@@ -127,9 +136,85 @@
 - 维度变更 → `Sys*Updated.dimensionChanged + beforeSystemCode/beforeTenantId`：同时刷新
   新旧两个缓存槽位（如 [AccessRuleIpsBySubSysAndTenantIdCache.onParentUpdated]）
 
-**租户键归一化**：`tenantId` 可为 null（平台级）/空白/具体值。统一由
-`AccessRuleTenantKey.compositeKey(systemCode, tenantId)` 归一为 `systemCode::tenantId`，
-null/空白都映射到空串 —— `@Cacheable` SpEL 和 `doReload` 必须保持一致。
+### 事件清单
+
+每个业务模块有一个 `sealed interface Sys*Event` 与四种 `data class`：`Inserted` / `Updated` / `Deleted` / `BatchDeleted`。Service 在事务内 `applicationEventPublisher.publishEvent(...)`，`*Cache` 用 `@TransactionalEventListener(phase = AFTER_COMMIT, fallbackExecution = true)` 订阅。
+
+| 模块 | 事件 sealed 根 | 文件 | 维度键 / 注意点 |
+|------|--------------|------|----------------|
+| `accessrule` | `SysAccessRuleEvent` | `accessrule/event/AccessRuleEvents.kt` | Inserted/Updated/Deleted 携带 `(systemCode, tenantId)`；Updated 额外有 `before*` + `dimensionChanged`；BatchDeleted 携带 `dimensions: List<Pair<String, String?>>` |
+| `accessrule` (IP) | `SysAccessRuleIpEvent` | `accessrule/event/AccessRuleIpEvents.kt` | 子事件按 **父规则维度** `parentSystemCode/parentTenantId` 携带；Insert/Update 携带 `active` 标志 |
+| `cache` | `SysCacheEvent` | `cache/event/SysCacheEvents.kt` | 纯按 id |
+| `datasource` | `SysDataSourceEvent` | `datasource/event/DataSourceEvents.kt` | 纯按 id |
+| `dict` | `SysDictEvent` | `dict/event/DictEvents.kt` | 纯按 id |
+| `dict` (item) | `SysDictItemEvent` | `dict/event/DictItemEvents.kt` | Deleted 含父字典 id 等附加字段（见源码） |
+| `domain` | `SysDomainEvent` | `domain/event/DomainEvents.kt` | Deleted 含 `name`（按名查缓存 `DomainByNameCache`） |
+| `i18n` | `SysI18nEvent` | `i18n/event/I18nEvents.kt` | 纯按 id |
+| `locale` | `SysLocaleEvent` | `locale/event/LocaleEvents.kt` | Deleted 含 `code`（按 code 缓存 `LocaleByCodeCache`） |
+| `microservice` | `SysMicroServiceEvent` | `microservice/event/MicroServiceEvents.kt` | 纯按 id |
+| `outline` | `SysOutLineEvent` | `outline/event/OutLineEvents.kt` | Deleted 含 `(systemCode, tenantId)` 维度键 |
+| `param` | `SysParamEvent` | `param/event/ParamEvents.kt` | Deleted 含 `(moduleName, paramName)` |
+| `resource` | `SysResourceEvent` | `resource/event/ResourceEvents.kt` | 纯按 id |
+| `system` | `SysSystemEvent` | `system/event/SystemEvents.kt` | 纯按 id |
+| `tenant` | `SysTenantEvent` | `tenant/event/TenantEvents.kt` | 纯按 id |
+| `tenant` (system 绑定) | `SysTenantSystemEvent` | `tenant/event/TenantSystemEvents.kt` | 维度键 `(tenantId, subSystemCode)`，由 `SysTenantSystemHashCache` 订阅 |
+
+**模板**（accessrule 是最完整范例，其他模块按需裁剪）：
+
+```kotlin
+sealed interface SysXxxEvent { val id: String }
+
+data class SysXxxInserted(override val id: String, /* 维度键... */) : SysXxxEvent
+data class SysXxxUpdated(
+    override val id: String,
+    /* 当前维度键 */
+    /* before* 维度键（如有维度迁移可能）*/
+) : SysXxxEvent {
+    val dimensionChanged: Boolean get() = /* before != current */
+}
+data class SysXxxDeleted(override val id: String, /* 维度键 snapshot */) : SysXxxEvent
+data class SysXxxBatchDeleted(
+    val ids: Collection<String>,
+    val dimensions: List<Pair<...>>,   // AFTER_COMMIT 时行已删，必须提前 snapshot
+) : SysXxxEvent { override val id get() = ids.first() }
+```
+
+**为何 BatchDeleted 一定要带 dimensions**：`AFTER_COMMIT` 触发时 DB 行已被删除，订阅方反查必空——所以 Service 必须在删除前把维度键 snapshot 进事件载荷。漏带 = 缓存脏数据。新加按维度键聚合的缓存时，必须同步检查对应 BatchDeleted 是否携带了所需维度。
+
+**复合键归一化**：`tenantId` 可为 null（平台级）/ 空白 / 具体值。
+- 访问规则 IP：`AccessRuleTenantKey.compositeKey(systemCode, tenantId)` → `systemCode::tenantId`
+- 大纲：`OutLineSystemTenantKey.compositeKey(systemCode, tenantId)` 同形态
+
+null / 空白都映射到空串 —— `@Cacheable` SpEL 和 `doReload` 必须保持一致；新增按 (subSystem,
+tenant) 维度的缓存时，**复用现有 `*Key` 工具**，不要在 SpEL 里手写 `?:''` 拼串。
+
+**Cache 基类三选一**（来自 `kudos-ability-cache-common`）：
+
+| 基类 | 用途 |
+|------|------|
+| `AbstractByIdCacheHandler<ID, V, DAO>` | 按主键单条缓存（`TenantByIdCache`、`DomainByNameCache`） |
+| `AbstractKeyValueCacheHandler<K, V>` | 任意 key→value，复合键场景（`AccessRuleIpsBySubSysAndTenantIdCache`、`OutLineBySystemAndTenantCache`、`LocaleByCodeCache`） |
+| `AbstractHashCacheHandler<F, V>` | Redis Hash 形态的"全量分组"缓存（`SysDictHashCache`、`SysI18nHashCache` 等） |
+
+**典型形态**：
+
+```kotlin
+open class TenantByIdCache : AbstractByIdCacheHandler<String, SysTenantCacheEntry, SysTenantDao>() {
+    fun getTenantById(id: String): SysTenantCacheEntry? =
+        getSelf<TenantByIdCache>().doReload(id)        // 自调用必须走代理
+
+    @Cacheable(cacheNames = [CACHE_NAME], key = "#id", unless = "#result == null")
+    override fun doReload(id: String): SysTenantCacheEntry? = /* DAO 查询 */
+
+    @TransactionalEventListener(phase = AFTER_COMMIT, fallbackExecution = true)
+    open fun onUpdated(event: SysTenantUpdated) {
+        getSelf<TenantByIdCache>().evict(event.id)
+    }
+}
+```
+
+- **`getSelf<XxxCache>()`** 拿到 Spring CGLIB 代理对象——同类内部直接调 `this.foo()` 会绕过代理，`@Cacheable` / `@CacheEvict` 不生效。Kotlin + Spring AOP 的固有坑。
+- **`fallbackExecution = true`** 让事件在无事务上下文（如直接 publish）时也执行，避免漏失效。
 
 ## 已知限制 / 安全考量
 

--- a/kudos-ms/kudos-ms-sys/kudos-ms-sys-sql/README.md
+++ b/kudos-ms/kudos-ms-sys/kudos-ms-sys-sql/README.md
@@ -16,31 +16,42 @@
 resources/sql/sys/h2/
 ```
 
-当前迁移文件按版本号递增（示例，以仓库内实际文件为准）：
+当前迁移文件按版本号递增：
 
-| 迁移文件 | 概要 |
-|----------|------|
-| `V1.0.0.1__init_sys_system.sql` | 子系统（system） |
-| `V1.0.0.2__init_sys_micro_service.sql` | 微服务 |
-| `V1.0.0.3__init_sys_sub_system_micro_service.sql` | 子系统与微服务绑定 |
-| `V1.0.0.4__init_sys_tenant.sql` | 租户 |
-| `V1.0.0.5__init_sys_tenant_system.sql` | 租户与子系统 |
-| `V1.0.0.6__init_sys_tenant_locale.sql` | 租户语言 |
-| `V1.0.0.7__init_sys_data_source.sql` | 数据源 |
-| `V1.0.0.8__init_sys_dict.sql` | 字典 |
-| `V1.0.0.9__init_sys_dict_item.sql` | 字典项 |
-| `V1.0.0.10__init_v_sys_dict_item.sql` | 字典项视图 |
-| `V1.0.0.11__init_sys_cache.sql` | 缓存配置 |
-| `V1.0.0.12__init_sys_resource.sql` | 资源（含菜单等） |
-| `V1.0.0.13__init_sys_tenant_resource.sql` | 租户与资源 |
-| `V1.0.0.14__init_sys_param.sql` | 参数 |
-| `V1.0.0.15__init_sys_domain.sql` | 域 |
-| `V1.0.0.16__init_sys_i18n.sql` | 国际化 |
-| `V1.0.0.17__init_sys_access_rule.sql` | 访问规则 |
-| `V1.0.0.18__init_sys_access_rule_ip.sql` | 访问规则 IP |
-| `V1.0.0.19__init_v_sys_access_rule_ip.sql` | 访问规则与 IP 联合视图 |
+| 迁移文件 | 类型 | 概要 |
+|----------|------|------|
+| `V1.0.0.1__init_sys_system.sql` | DDL | 子系统（system） |
+| `V1.0.0.2__init_sys_micro_service.sql` | DDL | 微服务 |
+| `V1.0.0.3__init_sys_sub_system_micro_service.sql` | DDL | 子系统与微服务绑定 |
+| `V1.0.0.4__init_sys_tenant.sql` | DDL | 租户 |
+| `V1.0.0.5__init_sys_tenant_system.sql` | DDL | 租户与子系统 |
+| `V1.0.0.6__init_sys_tenant_locale.sql` | DDL | 租户语言（早期表；后由 `V1.0.0.23` 引入的 `sys_locale` 主表取代承载语言主数据） |
+| `V1.0.0.7__init_sys_data_source.sql` | DDL | 数据源 |
+| `V1.0.0.8__init_sys_dict.sql` | DDL | 字典 |
+| `V1.0.0.9__init_sys_dict_item.sql` | DDL | 字典项 |
+| `V1.0.0.10__init_v_sys_dict_item.sql` | DDL（视图） | `v_sys_dict_item`：字典项 + 字典头联合查询 |
+| `V1.0.0.11__init_sys_cache.sql` | DDL | 缓存配置元数据 |
+| `V1.0.0.12__init_sys_resource.sql` | DDL | 资源（含菜单等） |
+| `V1.0.0.13__init_sys_tenant_resource.sql` | DDL | 租户与资源 |
+| `V1.0.0.14__init_sys_param.sql` | DDL | 参数 |
+| `V1.0.0.15__init_sys_domain.sql` | DDL | 域 |
+| `V1.0.0.16__init_sys_i18n.sql` | DDL | 国际化 |
+| `V1.0.0.17__init_sys_access_rule.sql` | DDL | 访问规则 |
+| `V1.0.0.18__init_sys_access_rule_ip.sql` | DDL | 访问规则 IP（含 IP 段 start/end） |
+| `V1.0.0.19__init_v_sys_access_rule_ip.sql` | DDL（视图） | `v_sys_access_rule_ip`：规则 + IP 联合视图（对应 `VSysAccessRuleWithIpDao`） |
+| `V1.0.0.20__add_missing_fk_indexes.sql` | DDL（refinement） | 补建关键外键索引：`sys_access_rule_ip.parent_rule_id`、`sys_dict_item.dict_id` / `parent_id` |
+| `V1.0.0.21__add_platform_access_rule_uniq.sql` | DDL（refinement） | 删除旧约束并以 `nulls not distinct` 重建 `uq_sys_access_rule` 唯一索引，使平台级（`tenant_id` 为 NULL）规则也参与唯一性 |
+| `V1.0.0.22__init_sys_out_line.sql` | DDL | 大纲（OutLine）：按 (子系统,租户) 维度可缓存的轮廓数据 |
+| `V1.0.0.23__init_sys_locale.sql` | DDL | 语言/区域主数据，配合 `LocaleByCodeCache` |
+| `V1.0.0.24__seed_sys_locale_cache.sql` | DML（seed） | 写入默认语言数据，保证 cache 启动可用 |
+| `V1.0.0.25__seed_sys_out_line_cache.sql` | DML（seed） | 写入默认大纲数据 |
 
-> 目录名为 `h2`，与测试/本地常用 H2 方言一致；若生产使用其他数据库，可能另有同结构或方言适配脚本（以本仓库实际目录为准）。
+> 目录名为 `h2`，与测试/本地常用 H2 方言一致；当前生产/CI 也复用此目录，未维护独立的 PostgreSQL/MySQL 方言版本。脚本中部分语法（如 `nulls not distinct`、`comment on column`）依赖 H2 兼容层或目标 RDB 同名特性，新增脚本需在目标库回归验证。
+>
+> 与代码的双向关系：
+> - 命名 `Vx.y.z.n__init_<snake_case_table>.sql` 与 `core` 中 `Sys<PascalCase>Table` / `Sys<PascalCase>Dao` 严格一一对应（视图前缀 `v_` ↔ `VSys*Dao`）。
+> - DML（`seed_*`）保证启动后缓存对应表至少有一行兜底数据，对应 `core/*/cache/*Cache` 的 `loadXxx` 行为。
+> - 重命名或修列的 refinement 脚本需保持向前兼容（`drop constraint if exists`、`create index if not exists`），方便在已升级环境再次执行不报错。
 
 ---
 
@@ -55,5 +66,8 @@ resources/sql/sys/h2/
 
 ## 维护注意
 
-- 新增表或变更列：新增 **更高版本号** 的迁移文件，避免修改已发布版本脚本（除非团队约定可重建环境）。
-- 视图（`v_*`）与业务查询强相关，变更时需同步 `core` 中 DAO/实体与 `common` 中 VO。
+- 新增表或变更列：新增 **更高版本号** 的迁移文件，避免修改已发布版本脚本（除非团队约定可重建环境）。已发布脚本（V1.0.0.1–V1.0.0.19）的列错误一律通过 V1.0.0.20+ 的 **refinement 迁移** 修正。
+- 视图（`v_*`）与业务查询强相关，变更时需同步 `core` 中 `VSys*Dao` 与 `common` 中 VO。
+- **平台级数据**（`tenant_id` 为 NULL）唯一约束需使用 `nulls not distinct`（参见 V1.0.0.21）；普通 `UNIQUE` 在多数 RDB 上视 NULL 互不相等，会让平台级行重复插入而不报错。
+- **缓存依赖的 seed 数据**：新增以 `*Cache` 在启动期 `doReload` 的表时，配套提交 `seed_*` 迁移，避免空库时缓存为 null 引起 NPE。
+- **外键 / 高频过滤列必须建索引**：参考 V1.0.0.20。Ktorm 不会自动建索引；缺索引在多租户大表上会快速劣化。


### PR DESCRIPTION
…nternal misrepresentation, add outline/locale modules, event catalog, build/run/config keys

- api-internal: rewritten — module hosts 18 RPC controllers (not "empty shell"); document common.ISys*Api 三身一体 (core + api-internal controller + client proxy share same interface + method-level @*Mapping)
- core: add outline/locale business modules; replace fictional core.dao/core.service flat layout with actual core.<module>.<layer> structure; add complete event catalog (16 *Events.kt files across 13 modules); add config keys cheat-sheet (CacheConfigProvider reads sys_cache table, not yml); correct cache base class example (AbstractByIdCacheHandler etc.)
- sql: add migrations V1.0.0.20–25 (fk indexes, nulls-not-distinct uniq, sys_out_line, sys_locale, seed scripts)
- common: add locale + outline modules; mark ISysCacheApi as intentional empty contract placeholder; remove stale platform.validation reference
- api-admin: add missing SysOutLineAdminController + SysLocaleAdminController; correct SysDictItemAdminController path
- client: add ISysLocaleProxy + ISysOutLineProxy; document FeignDictItemCodeFinder (ServiceLoader fallback for downstream services without sys-core); document SysClientFallbackSupport compat layer
- top-level: redraw dependency diagram showing api-internal carrying RPC controllers; add path dual-track section (/api/admin vs /api/internal); add gradle build/run/test command reference