### PR TITLE
docs(base): backfill KDoc on private fns, properties, and inner classes

### DIFF
--- a/kudos-base/src/io/kudos/base/bean/BeanKit.kt
+++ b/kudos-base/src/io/kudos/base/bean/BeanKit.kt
@@ -283,6 +283,16 @@ object BeanKit {
 
     /**
      * 通过反射直接设置字段值，用于无 setter 的只读属性（如 Kotlin data class 的 val）。
+     *
+     * 字段查找会尝试两种命名：原始属性名；以及 JavaBean 风格 `isXxx` -> `xxx` 的回退。
+     * 沿继承链向上查找；命中后必要时通过 [ConvertUtils] 做一次类型转换再赋值。
+     *
+     * @param bean 目标对象
+     * @param name 属性名
+     * @param value 待写入值，null 直接写入
+     * @throws NoSuchFieldException 当继承链上都找不到该字段时
+     * @author K
+     * @since 1.0.0
      */
     private fun setPropertyByField(bean: Any, name: String, value: Any?) {
         val fieldNamesToTry = sequence {

--- a/kudos-base/src/io/kudos/base/bean/validation/constraint/annotations/Constraints.kt
+++ b/kudos-base/src/io/kudos/base/bean/validation/constraint/annotations/Constraints.kt
@@ -211,6 +211,11 @@ annotation class Constraints(
 ) {
 
     companion object {
+        /**
+         * 子约束 `message` 字段的占位默认值。
+         * 校验器通过 `message == MESSAGE` 判断用户是否实际启用了该子约束，
+         * 因此各子约束未被显式声明时都共享此占位值。
+         */
         const val MESSAGE = "TEMP_MSG" // 利用该值来确定用户定义了哪些子约束
     }
 

--- a/kudos-base/src/io/kudos/base/bean/validation/constraint/validator/ConstraintsValidator.kt
+++ b/kudos-base/src/io/kudos/base/bean/validation/constraint/validator/ConstraintsValidator.kt
@@ -28,6 +28,7 @@ import kotlin.reflect.full.declaredMemberProperties
  */
 class ConstraintsValidator : ConstraintValidator<Constraints, Any?> {
 
+    /** 当前实例处理的 [Constraints] 组合约束注解，由 [initialize] 注入 */
     private lateinit var constraints: Constraints
 
     override fun initialize(constraints: Constraints) {
@@ -62,10 +63,15 @@ class ConstraintsValidator : ConstraintValidator<Constraints, Any?> {
     }
 
     companion object {
+        /** Hibernate Validator 初始化方法（双参签名）的反射缓存 */
         private val hvInitMethodCache = ConcurrentHashMap<Class<*>, Method>()
+        /** 标准 [ConstraintValidator.initialize] 方法的反射缓存 */
         private val initMethodCache = ConcurrentHashMap<Class<*>, Method>()
+        /** [ConstraintValidator.isValid] 方法的反射缓存 */
         private val isValidMethodCache = ConcurrentHashMap<Class<*>, Method>()
+        /** 注解属性方法列表缓存：避免每次都遍历 declaredMethods */
         private val annotationAttributeMethodsCache = ConcurrentHashMap<Class<out Annotation>, List<Method>>()
+        /** 注解 `message` 属性方法的反射缓存 */
         private val annotationMessageMethodCache = ConcurrentHashMap<Class<out Annotation>, Method>()
         // 用 ConcurrentHashMap 取代了原先 `Collections.synchronizedMap(WeakHashMap)`：
         // - 原实现下所有 get/put 都串行在同一把锁上，是校验热路径上的真实争用点
@@ -83,9 +89,13 @@ class ConstraintsValidator : ConstraintValidator<Constraints, Any?> {
          */
         private val initializedValidators: MutableMap<ConstraintValidator<*, *>, Boolean> =
             ConcurrentHashMap()
+        /** [Constraints] 自身的元属性名，遍历子约束时需要排除 */
         private val excludedConstraintPropertyNames = setOf("order", "andOr", "message", "groups", "payload")
+        /** 复用的“空 composing constraints”集合，避免每次构造代理都新建 */
         private val emptyComposingConstraints: Set<ConstraintDescriptor<*>> = emptySet()
+        /** 复用的“空 validator classes”列表，避免每次构造代理都新建 */
         private val emptyValidatorClasses: List<Class<*>> = emptyList()
+        /** 强制优先校验的约束类型集合：null/blank/empty 一类必须先短路，提升错误信息可读性 */
         private val priorityConstraintTypes = setOf(
             NotBlank::class,
             NotEmpty::class,
@@ -93,6 +103,20 @@ class ConstraintsValidator : ConstraintValidator<Constraints, Any?> {
             Null::class
         )
 
+        /**
+         * 提取 [Constraints] 中所有实际启用的子约束，并按以下规则排序：
+         * 1) 显式 [Constraints.order] 中列出的约束优先按用户指定顺序；
+         * 2) 其余约束按反射遍历顺序追加；
+         * 3) 如果其中存在 NotBlank/NotEmpty/NotNull/Null，强制把它提到最前。
+         *
+         * 通过 `message != [Constraints.MESSAGE]` 判断用户是否真的启用了该子约束。
+         *
+         * @param constraints 组合约束注解
+         * @return 排好序的子约束列表
+         * @throws IllegalStateException 当 order 中引用了未启用的约束类，或反射出非注解属性时
+         * @author K
+         * @since 1.0.0
+         */
         fun getAnnotations(constraints: Constraints): List<Annotation> {
             // 获取定义的子约束
             val annotations = mutableListOf<Annotation>()
@@ -139,6 +163,16 @@ class ConstraintsValidator : ConstraintValidator<Constraints, Any?> {
             }
         }
 
+        /**
+         * 通过反射读取注解的 `message` 属性值。
+         * 方法本身按注解类缓存，第二次读取同一类注解时不再走 [Class.getDeclaredMethod]。
+         *
+         * @param annotation 任意约束注解
+         * @return 注解的 message 值
+         * @throws IllegalStateException 当注解的 `message` 返回值不是 String 时
+         * @author K
+         * @since 1.0.0
+         */
         private fun getAnnotationMessage(annotation: Annotation): String {
             val annotationClass = annotation.annotationClass.java
             val method = annotationMessageMethodCache.getOrPut(annotationClass) {
@@ -149,6 +183,21 @@ class ConstraintsValidator : ConstraintValidator<Constraints, Any?> {
         }
     }
 
+    /**
+     * 单个子约束的校验入口：
+     * - null 值除 NotNull/NotEmpty/NotBlank 外一律视为通过；
+     * - [AtLeast] 子约束语义上作用在 bean 本身而非属性值，从 [ValidationContext] 取出 bean；
+     * - 通过 [ValidatorFactory] 拿到该注解对应的所有 [ConstraintValidator] 并依次执行，全通过才算通过。
+     *
+     * @param annotation 待执行的子约束
+     * @param value 被校验的属性值
+     * @param bean 当前正在校验的目标对象（[AtLeast] 等需要）
+     * @param context Bean Validation 上下文
+     * @return 该子约束是否通过
+     * @throws IllegalStateException 当找不到对应的 ConstraintValidator 时
+     * @author K
+     * @since 1.0.0
+     */
     private fun validate(
         annotation: Annotation,
         value: Any?,
@@ -178,6 +227,21 @@ class ConstraintsValidator : ConstraintValidator<Constraints, Any?> {
     }
 
 
+    /**
+     * 反射调用单个 [ConstraintValidator] 的 initialize + isValid。
+     *
+     * 对实现了 [HibernateConstraintValidator] 的校验器走双参 initialize（descriptor + initCtx），
+     * 否则走标准 initialize(annotation)。同一 validator 实例只初始化一次，由 [initializedValidators] 兜底。
+     *
+     * @param constraintValidator 已实例化的校验器
+     * @param annotation 当前子约束
+     * @param value 被校验的值
+     * @param context Bean Validation 上下文
+     * @return [ConstraintValidator.isValid] 返回值
+     * @throws IllegalStateException 反射查不到 initialize/isValid，或 isValid 返回值不是 Boolean 时
+     * @author K
+     * @since 1.0.0
+     */
     private fun doValidate(
         constraintValidator: ConstraintValidator<*, *>,
         annotation: Annotation,
@@ -219,6 +283,15 @@ class ConstraintsValidator : ConstraintValidator<Constraints, Any?> {
             ?: error("ConstraintValidator.isValid必须返回Boolean")
     }
 
+    /**
+     * 用子约束自身的 message 追加一条 violation，并禁用默认 violation。
+     * 关闭默认 violation 是为了避免组合约束之外又额外冒出 Constraints 自己的默认错误信息。
+     *
+     * @param context Bean Validation 上下文
+     * @param annotation 失败的子约束
+     * @author K
+     * @since 1.0.0
+     */
     private fun addViolation(context: ConstraintValidatorContext, annotation: Annotation) {
         context.disableDefaultConstraintViolation()
         val message = getAnnotationMessage(annotation)
@@ -256,6 +329,17 @@ class ConstraintsValidator : ConstraintValidator<Constraints, Any?> {
     private fun proxyConstraintDescriptor(annotation: Annotation): ConstraintDescriptor<*> =
         constraintDescriptorCache.computeIfAbsent(annotation) { buildConstraintDescriptorProxy(it) }
 
+    /**
+     * 实际构造 [ConstraintDescriptor] 代理对象的实现。
+     * 反射读取注解的所有属性方法（按注解类缓存），用 JDK [Proxy] 暴露最小集合的接口方法：
+     * getAnnotation / getAttributes / getMessageTemplate / getGroups / getPayload 等。
+     *
+     * @param annotation 当前子约束
+     * @return ConstraintDescriptor 代理实例
+     * @throws IllegalStateException Proxy 实例化失败时
+     * @author K
+     * @since 1.0.0
+     */
     private fun buildConstraintDescriptorProxy(annotation: Annotation): ConstraintDescriptor<*> {
         val attributeMethods = annotationAttributeMethodsCache.getOrPut(annotation.annotationClass.java) {
             annotation.annotationClass.java.declaredMethods
@@ -294,6 +378,15 @@ class ConstraintsValidator : ConstraintValidator<Constraints, Any?> {
             ?: error("构造 ConstraintDescriptor 代理失败")
     }
 
+    /**
+     * 给 ConstraintDescriptor 代理上未列出的方法返回类型安全的零值。
+     * 基本类型按规范返回 0/false/' '；Set / List 返回空集合；其它对象返回 null。
+     *
+     * @param type 方法返回类型
+     * @return 类型安全的“默认值”
+     * @author K
+     * @since 1.0.0
+     */
     private fun defaultReturn(type: Class<*>): Any? = when {
         type == java.lang.Boolean.TYPE -> false
         type == Integer.TYPE -> 0

--- a/kudos-base/src/io/kudos/base/bean/validation/constraint/validator/SeriesValidator.kt
+++ b/kudos-base/src/io/kudos/base/bean/validation/constraint/validator/SeriesValidator.kt
@@ -14,6 +14,7 @@ import java.math.BigDecimal
  */
 class SeriesValidator : ConstraintValidator<Series, Any?> {
 
+    /** 当前实例处理的 [Series] 注解，由 [initialize] 注入 */
     private lateinit var series: Series
 
     override fun initialize(series: Series) {
@@ -80,6 +81,16 @@ class SeriesValidator : ConstraintValidator<Series, Any?> {
         }
     }
 
+    /**
+     * 用自定义 message 替换默认 violation 并返回 false。
+     * 用在“值非法到根本无法继续校验”的早退路径（如类型不对、含 null 元素）。
+     *
+     * @param context Bean Validation 上下文
+     * @param message 自定义错误信息模板
+     * @return 永远返回 false
+     * @author K
+     * @since 1.0.0
+     */
     private fun fail(context: ConstraintValidatorContext, message: String): Boolean {
         context.disableDefaultConstraintViolation()
         context.buildConstraintViolationWithTemplate(message).addConstraintViolation()

--- a/kudos-base/src/io/kudos/base/bean/validation/support/RegExps.kt
+++ b/kudos-base/src/io/kudos/base/bean/validation/support/RegExps.kt
@@ -11,6 +11,13 @@ package io.kudos.base.bean.validation.support
  */
 object RegExps {
 
+    /**
+     * 通信与联系方式相关正则。
+     * 包含手机号、固定电话、QQ、邮箱、微信号等场景。
+     *
+     * @author K
+     * @since 1.0.0
+     */
     object Communication {
 
         /**
@@ -121,6 +128,13 @@ object RegExps {
         const val WECHAT_ID = "^[a-zA-Z0-9]{1}[-_a-zA-Z0-9]{5,19}$"
     }
 
+    /**
+     * 人名 / 显示名相关正则。
+     * 包含真实姓名、银行账户户名、昵称等限制更严格的姓名字段。
+     *
+     * @author K
+     * @since 1.0.0
+     */
     object Name {
 
         /**
@@ -195,6 +209,13 @@ object RegExps {
         const val NICK_NAME = "^[a-zA-Z0-9\\u4E00-\\u9FA5\\u0800-\\u4e00]{3,15}$"
     }
 
+    /**
+     * 通用文本相关正则。
+     * 主要约束字符集、长度与首字符等，不针对具体业务字段。
+     *
+     * @author K
+     * @since 1.0.0
+     */
     object Text {
 
         /**
@@ -279,6 +300,13 @@ object RegExps {
         const val CONTEXT = "^/(?:[a-z0-9]+(?:-[a-z0-9]+)*/?)*$"
     }
 
+    /**
+     * 字符集合相关正则。
+     * 用于校验字符串只包含特定字符种类（字母、数字、连字符、下划线等）。
+     *
+     * @author K
+     * @since 1.0.0
+     */
     object CharacterSet {
 
         /**
@@ -421,6 +449,13 @@ object RegExps {
         const val SLUG_KEBAB_LOWERCASE = "^[a-z0-9]+(?:-[a-z0-9]+)*$"
     }
 
+    /**
+     * 安全相关正则。
+     * 包含登录密码、PIN 码、以及密码强度判定使用的规则集。
+     *
+     * @author K
+     * @since 1.0.0
+     */
     object Security {
 
         /**
@@ -500,6 +535,13 @@ object RegExps {
             "^[A-Za-z0-9~!@#$%^&*()_+\\\\{\\\\}\\\\[\\\\]|\\\\:;\\'\\\"<>,./?]+$"
     }
 
+    /**
+     * 数值文本相关正则。
+     * 包含整数、正数、金额、百分比、比分等以字符串形式表达的数字格式。
+     *
+     * @author K
+     * @since 1.0.0
+     */
     object Numeric {
 
         /**
@@ -649,6 +691,13 @@ object RegExps {
         const val PERCENT_INTEGER_0_100 = "^(?:100|[1-9]\\d?|0)$"
     }
 
+    /**
+     * 网络与协议相关正则。
+     * 包含 IPv4、IPv6、URL、JDBC、MAC、端口、域名、CIDR 等表达。
+     *
+     * @author K
+     * @since 1.0.0
+     */
     object Network {
 
         /**
@@ -823,6 +872,13 @@ object RegExps {
         const val DOMAIN = "^(localhost|(?=.{1,253}$)(?!-)(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\\.)+[A-Za-z]{2,63})$"
     }
 
+    /**
+     * 业务专用正则。
+     * 含银行卡号、玩家账号、站点 ID 列表等明显与领域绑定的字段。
+     *
+     * @author K
+     * @since 1.0.0
+     */
     object Business {
 
         /**
@@ -867,6 +923,13 @@ object RegExps {
         const val GAME_PLAYER_ACCOUNT = "^[a-zA-Z0-9_\\$][a-zA-Z0-9_]{3,14}$"
     }
 
+    /**
+     * 通用格式相关正则。
+     * 含 UUID、日期、时间、邮编、十六进制颜色等可复用的标准化格式。
+     *
+     * @author K
+     * @since 1.0.0
+     */
     object Format {
 
         /**

--- a/kudos-base/src/io/kudos/base/bean/validation/support/ValidationContext.kt
+++ b/kudos-base/src/io/kudos/base/bean/validation/support/ValidationContext.kt
@@ -21,11 +21,17 @@ object ValidationContext {
 
     /** 缓存 HV 的 initializationContext */
     private var hvInitCtx: HibernateConstraintValidatorInitializationContext? = null
+    /** Jakarta 标准约束注解的包名前缀，用于剔除非业务注解 */
     private const val jakartaAnnotationPrefix = "jakarta"
+    /** Hibernate Validator 内置约束注解的包名前缀，用于剔除非业务注解 */
     private const val hibernateAnnotationPrefix = "org.hibernate"
+    /** 反射查 `getValidatorFactoryScopedContext` 方法的缓存 */
     private val scopedContextMethodCache = ConcurrentHashMap<Class<*>, Method>()
+    /** 反射查 `validatorFactoryScopedContext` 字段的缓存（方法路径失败时退回字段） */
     private val scopedContextFieldCache = ConcurrentHashMap<Class<*>, Field>()
+    /** 反射查 `getConstraintValidatorInitializationContext` 方法的缓存 */
     private val initCtxMethodCache = ConcurrentHashMap<Class<*>, Method>()
+    /** 注解类是否“业务自定义约束”的判定缓存：包名既不属 jakarta 也不属 org.hibernate */
     private val businessConstraintAnnotationCache = ConcurrentHashMap<Class<out Annotation>, Boolean>()
 
     /**
@@ -35,10 +41,27 @@ object ValidationContext {
      */
     private val descriptorAccessorCache = ConcurrentHashMap<Class<*>, (Any) -> ConstraintDescriptor<*>?>()
 
+    /**
+     * 注入构建好的 [jakarta.validation.ValidatorFactory]，
+     * 立即从中提取 Hibernate Validator 的初始化上下文并缓存。
+     * 应用启动时调用一次。
+     *
+     * @param factory 已经构建好的 ValidatorFactory
+     * @author K
+     * @since 1.0.0
+     */
     fun setFactory(factory: jakarta.validation.ValidatorFactory) {
         hvInitCtx = extractHvInitCtx(factory)
     }
 
+    /**
+     * 获取已缓存的 [HibernateConstraintValidatorInitializationContext]。
+     *
+     * @return HV 初始化上下文
+     * @throws IllegalStateException 未先调用 [setFactory] 注入 ValidatorFactory 时
+     * @author K
+     * @since 1.0.0
+     */
     fun getHvInitCtx(): HibernateConstraintValidatorInitializationContext {
         return hvInitCtx ?: error("HibernateConstraintValidatorInitializationContext 尚未初始化：请确保先调用 ValidationKit.getValidator() 构建 ValidatorFactory")
     }
@@ -113,6 +136,19 @@ object ValidationContext {
         set(validator, bean, null, beanMapThreadLocal.get())
     }
 
+    /**
+     * 递归遍历 bean 的所有约束属性，把每个非 Jakarta/HV 约束的 [ConstraintDescriptor] hashcode
+     * 与 bean 自身关联存入 [beanStore]，使自定义约束校验器后续能取回 bean。
+     *
+     * 嵌套 `@Valid` 属性也会递归处理；List 元素会按 `[i]` 拼接路径。
+     *
+     * @param validator 当前使用的 [Validator]
+     * @param bean 待存入上下文的 bean
+     * @param parentPath 父级路径（用于嵌套属性的展示，目前未对外暴露）
+     * @param beanStore 线程局部存储
+     * @author K
+     * @since 1.0.0
+     */
     private fun set(
         validator: Validator,
         bean: Any,
@@ -191,6 +227,16 @@ object ValidationContext {
         return accessor(ctx)
     }
 
+    /**
+     * 为指定的 ConstraintValidatorContext 运行时类构造一个 descriptor 读取闭包。
+     * 优先使用 `getConstraintDescriptor()` 方法，方法找不到时退回 `constraintDescriptor` 字段，
+     * 兜底返回常量 null 闭包（适用 mock 或非 HV 实现）。
+     *
+     * @param clazz ConstraintValidatorContext 的具体运行时类
+     * @return 把 ctx 实例映射到 [ConstraintDescriptor] 的闭包
+     * @author K
+     * @since 1.0.0
+     */
     private fun buildDescriptorAccessor(clazz: Class<*>): (Any) -> ConstraintDescriptor<*>? {
         findInHierarchy(clazz) { it.getDeclaredMethod("getConstraintDescriptor") }?.let { method ->
             method.isAccessible = true
@@ -204,6 +250,17 @@ object ValidationContext {
         return { _ -> null }
     }
 
+    /**
+     * 沿继承链向上查找，把 [finder] 应用到每一层。
+     * 任意一层返回非 null 即停止；finder 抛异常视为该层不命中。
+     *
+     * @param R 查找目标类型（[Method] 或 [Field]）
+     * @param clazz 起始类
+     * @param finder 在单个类上执行查找的闭包
+     * @return 首个命中的结果；都查不到返回 null
+     * @author K
+     * @since 1.0.0
+     */
     private inline fun <R : Any> findInHierarchy(clazz: Class<*>, finder: (Class<*>) -> R): R? {
         var current: Class<*>? = clazz
         while (current != null) {

--- a/kudos-base/src/io/kudos/base/bean/validation/support/ValidatorFactory.kt
+++ b/kudos-base/src/io/kudos/base/bean/validation/support/ValidatorFactory.kt
@@ -56,6 +56,7 @@ private typealias ValidatorBuilder = (annotation: Annotation, value: Any) -> Lis
  */
 object ValidatorFactory {
 
+    /** validator 实例缓存：按 (annotation, value 的运行时 class) 命中，避免重复构造与 initialize */
     private val CACHE: MutableMap<CacheKey, List<ConstraintValidator<*, *>>> = ConcurrentHashMap()
 
     /**
@@ -77,15 +78,41 @@ object ValidatorFactory {
         CACHE.clear()
     }
 
+    /**
+     * 缓存未命中时的实际构造路径：在 [BUILDERS] 注册表里查 annotation 对应的工厂闭包并执行。
+     *
+     * @param annotation 当前注解
+     * @param value 被校验的值（用于按运行时类型分发）
+     * @return 该注解对应的 validator 列表，未注册的注解返回空列表
+     * @author K
+     * @since 1.0.0
+     */
     private fun build(annotation: Annotation, value: Any): List<ConstraintValidator<*, *>> {
         val builder = BUILDERS[annotation.annotationClass] ?: return emptyList()
         return builder(annotation, value)
     }
 
+    /**
+     * validator 缓存的复合键。
+     * annotation 本身参与 hashCode/equals 依赖 JDK Annotation 的“同 attribute 即相等”契约。
+     *
+     * @property annotation 当前注解实例
+     * @property valueClass 被校验值的运行时类，用于不同类型分发的 validator 各自缓存
+     */
     private data class CacheKey(val annotation: Annotation, val valueClass: Class<*>)
 
     // ----------------------------- helpers -----------------------------
 
+    /**
+     * 抹掉 ConstraintValidator 的泛型实参，统一调用 [ConstraintValidator.initialize] 并返回自身，
+     * 便于在工厂闭包里以链式风格构造列表。
+     *
+     * @param validator 已实例化的校验器
+     * @param annotation 用来初始化的注解
+     * @return 同一个 validator 实例
+     * @author K
+     * @since 1.0.0
+     */
     private fun initialize(
         validator: ConstraintValidator<*, *>,
         annotation: Annotation
@@ -212,6 +239,18 @@ object ValidatorFactory {
         listOf(initialize(factory(), annotation))
     }
 
+    /**
+     * 反射构造注解实例：按形参名匹配 [namedArgs]，没匹配上的参数使用默认值。
+     * 用于把复合约束（Range、CreditCardNumber）拆解成内部更小的约束（Min/Max、LuhnCheck）后转交对应 validator。
+     *
+     * @param A 目标注解类型
+     * @param annotationClass 目标注解的 KClass
+     * @param namedArgs 形参名到实参值的映射
+     * @return 实例化好的注解
+     * @throws IllegalStateException 找不到注解构造器时
+     * @author K
+     * @since 1.0.0
+     */
     private fun <A : Annotation> createAnnotationByNamedArgs(
         annotationClass: KClass<A>,
         namedArgs: Map<String, Any>
@@ -233,6 +272,11 @@ object ValidatorFactory {
 
     // ----------------------------- registry -----------------------------
 
+    /**
+     * 注解类型到 validator 构造闭包的注册表。
+     * 新增一种注解仅需在此表追加一项；按值类型分发的注解走 [numericBound] / [dateBound] / [sizeBound] 模板，
+     * 复合注解（Range = Min+Max、CreditCardNumber → LuhnCheck）使用就地 lambda 拆解。
+     */
     private val BUILDERS: Map<KClass<out Annotation>, ValidatorBuilder> = buildMap {
         // ---- jakarta.validation ----
         this[AssertFalse::class] = raw { AssertFalseValidator() }

--- a/kudos-base/src/io/kudos/base/bean/validation/terminal/TerminalConstraintsCreator.kt
+++ b/kudos-base/src/io/kudos/base/bean/validation/terminal/TerminalConstraintsCreator.kt
@@ -190,6 +190,15 @@ object TerminalConstraintsCreator {
     /**
      * 递归获取 Getter 上的约束注解。
      * 当子类 override 属性但未重新声明约束时，继续向父接口和父类上查找。
+     *
+     * 使用 [visited] 集合防御接口多继承造成的菱形重复访问；遇到 [Any] 时立即停止。
+     *
+     * @param clazz 当前要扫描的类
+     * @param property 属性名
+     * @param visited 已访问过的类集合（防重）
+     * @return 命中的约束注解列表（可能为空）
+     * @author K
+     * @since 1.0.0
      */
     private fun collectAnnotationsOnGetter(
         clazz: KClass<*>,

--- a/kudos-base/src/io/kudos/base/cn/IdCardNoKit.kt
+++ b/kudos-base/src/io/kudos/base/cn/IdCardNoKit.kt
@@ -253,6 +253,15 @@ object IdCardNoKit {
         return !str.isBlank() && str.matches("^[1|57][0-9]{6}\\(?[0-9A-Z]\\)?$".toRegex())
     }
 
+    /**
+     * 将字符数组按 ASCII 偏移转换为数字数组（'0'..'9' -> 0..9）。
+     * 入参未做数字字符校验，调用方需先保证输入仅含数字字符。
+     *
+     * @param ca 待转换的字符数组
+     * @return 与入参等长的整型数组
+     * @author K
+     * @since 1.0.0
+     */
     private fun convertCharToInt(ca: CharArray): IntArray {
         val len = ca.size
         val iArr = IntArray(len)

--- a/kudos-base/src/io/kudos/base/data/json/JsonFallbackEncoder.kt
+++ b/kudos-base/src/io/kudos/base/data/json/JsonFallbackEncoder.kt
@@ -48,11 +48,19 @@ import kotlin.reflect.jvm.javaMethod
 @PublishedApi
 internal object JsonFallbackEncoder {
 
+    /**
+     * data class 属性的“名字 + 读取闭包”。
+     * 读取闭包优先用 Java getter；不可用时退回 Kotlin 反射，避免每次都走完整反射链。
+     *
+     * @property name 属性名
+     * @property read 读取属性值的闭包；失败返回 null 而非抛出
+     */
     private data class DataClassPropertyAccessor(
         val name: String,
         val read: (Any) -> Any?
     )
 
+    /** 通过反射拿到的 `Json.encodeToString(SerializationStrategy, T)` 方法句柄，避开重载歧义 */
     private val encodeToStringMethod: Method by lazy {
         Json::class.java.methods.firstOrNull {
             it.name == "encodeToString" &&
@@ -60,6 +68,7 @@ internal object JsonFallbackEncoder {
                 SerializationStrategy::class.java.isAssignableFrom(it.parameterTypes[0])
         } ?: error("Json.encodeToString(serializer, value) 方法不存在")
     }
+    /** 通过反射拿到的 `Json.encodeToJsonElement(SerializationStrategy, T)` 方法句柄 */
     private val encodeToJsonElementMethod: Method by lazy {
         Json::class.java.methods.firstOrNull {
             it.name == "encodeToJsonElement" &&
@@ -67,7 +76,9 @@ internal object JsonFallbackEncoder {
                 SerializationStrategy::class.java.isAssignableFrom(it.parameterTypes[0])
         } ?: error("Json.encodeToJsonElement(serializer, value) 方法不存在")
     }
+    /** data class 属性访问器缓存，按类缓存，避免每次序列化都遍历构造器与成员属性 */
     private val dataClassPropertyCache = ConcurrentHashMap<KClass<*>, List<DataClassPropertyAccessor>>()
+    /** Java Bean 读取方法缓存，避免每次序列化都执行 [Introspector.getBeanInfo] */
     private val javaBeanReadMethodCache = ConcurrentHashMap<Class<*>, List<Pair<String, Method>>>()
 
     /**
@@ -100,11 +111,31 @@ internal object JsonFallbackEncoder {
             ?: error("Json.encodeToString 返回值类型异常")
     }
 
+    /**
+     * 反射调用 `Json.encodeToJsonElement(serializer, value)`，主要给 LocalDate/Time 等 contextual 类型用。
+     *
+     * @param json 配置好的 Json 引擎
+     * @param serializer 显式的序列化器
+     * @param value 待编码对象
+     * @return 编码后的 [JsonElement]
+     * @author K
+     * @since 1.0.0
+     */
     private fun encodeWithSerializerToElement(json: Json, serializer: KSerializer<*>, value: Any): JsonElement {
         return encodeToJsonElementMethod.invoke(json, serializer, value) as? JsonElement
             ?: error("Json.encodeToJsonElement 返回值类型异常")
     }
 
+    /**
+     * 快速分支：常见的基本类型 / 时间类型 / 集合 / 数组直接编码为 [JsonElement]，
+     * 没有命中则返回 null 让上层走 [encodeComplexObject] 复杂分支。
+     *
+     * @param json 配置好的 Json 引擎
+     * @param value 待编码对象，允许 null
+     * @return 命中快速分支返回对应 [JsonElement]，否则 null
+     * @author K
+     * @since 1.0.0
+     */
     private fun encodeFastPath(json: Json, value: Any?): JsonElement? {
         return when (value) {
             null -> JsonNull
@@ -134,6 +165,17 @@ internal object JsonFallbackEncoder {
         }
     }
 
+    /**
+     * 复杂分支：data class 走主构造参数顺序提取属性；其它对象退回 Java Bean 反射；
+     * 均无法处理时抛出 [SerializationException] 提示加 @Serializable。
+     *
+     * @param json 配置好的 Json 引擎
+     * @param value 非空待编码对象
+     * @return 对应的 [JsonObject]
+     * @throws SerializationException 类型既不是 data class、也无法按 Java Bean 反射时
+     * @author K
+     * @since 1.0.0
+     */
     private fun encodeComplexObject(json: Json, value: Any): JsonElement {
         val k = value::class
         if (k.isData) {
@@ -154,6 +196,15 @@ internal object JsonFallbackEncoder {
         )
     }
 
+    /**
+     * 把任意 [Iterable] 递归编码为 [JsonArray]，并尽量为 [Collection] 预分配容量。
+     *
+     * @param json 配置好的 Json 引擎
+     * @param value 待编码集合
+     * @return 编码后的 [JsonArray]
+     * @author K
+     * @since 1.0.0
+     */
     private fun encodeIterable(json: Json, value: Iterable<*>): JsonArray {
         val items = if (value is Collection<*>) {
             ArrayList<JsonElement>(value.size)
@@ -164,12 +215,31 @@ internal object JsonFallbackEncoder {
         return JsonArray(items)
     }
 
+    /**
+     * 把对象数组递归编码为 [JsonArray]。
+     *
+     * @param json 配置好的 Json 引擎
+     * @param value 待编码对象数组
+     * @return 编码后的 [JsonArray]
+     * @author K
+     * @since 1.0.0
+     */
     private fun encodeObjectArray(json: Json, value: Array<*>): JsonArray {
         val items = ArrayList<JsonElement>(value.size)
         value.forEach { items.add(encodeAnyToJsonElement(json, it)) }
         return JsonArray(items)
     }
 
+    /**
+     * 原始类型数组的统一编码模板：按下标读取并通过 [producer] 转为 [JsonElement]。
+     * inline 是为了避开数百次 lambda 调用的装箱开销。
+     *
+     * @param size 数组长度
+     * @param producer 把下标映射为 [JsonElement] 的闭包
+     * @return 编码后的 [JsonArray]
+     * @author K
+     * @since 1.0.0
+     */
     private inline fun encodePrimitiveArray(size: Int, producer: (Int) -> JsonElement): JsonArray {
         val items = ArrayList<JsonElement>(size)
         for (i in 0 until size) {
@@ -178,6 +248,16 @@ internal object JsonFallbackEncoder {
         return JsonArray(items)
     }
 
+    /**
+     * 把 [Map] 编码为 [JsonObject]：null key 转 `"null"`，非字符串 key 走 [Any.toString]。
+     * 与标准 kotlinx 行为略有差异，仅用于无 `@Serializable` 类型的兜底。
+     *
+     * @param json 配置好的 Json 引擎
+     * @param value 待编码的 Map
+     * @return 编码后的 [JsonObject]
+     * @author K
+     * @since 1.0.0
+     */
     private fun encodeMapToJsonObject(json: Json, value: Map<*, *>): JsonObject {
         return encodeObjectEntries(
             json = json,
@@ -194,6 +274,16 @@ internal object JsonFallbackEncoder {
         )
     }
 
+    /**
+     * 通过 [Introspector] 提取 Java Bean 风格的属性并编码为 [JsonObject]。
+     * 自动跳过 [Object] 自带属性（如 class），属性顺序由 Introspector 给出（一般按 getter 名字字典序）。
+     *
+     * @param json 配置好的 Json 引擎
+     * @param bean 待编码对象
+     * @return 编码后的 [JsonObject]
+     * @author K
+     * @since 1.0.0
+     */
     private fun javaBeanToJsonElement(json: Json, bean: Any): JsonElement {
         val readMethods = javaBeanReadMethodCache.getOrPut(bean.javaClass) {
             Introspector.getBeanInfo(bean.javaClass, Any::class.java).propertyDescriptors.mapNotNull { pd ->
@@ -212,6 +302,20 @@ internal object JsonFallbackEncoder {
         )
     }
 
+    /**
+     * 把任意条目集合（Map.Entry、Pair、属性元组等）按 keyOf/valueOf 投影为 [JsonObject]。
+     * 使用 [LinkedHashMap] 保证输出顺序与输入一致；为复用性把投影写成 inline 以避免闭包开销。
+     *
+     * @param T 条目类型
+     * @param json 配置好的 Json 引擎
+     * @param size 预分配的容量提示
+     * @param entries 待编码条目
+     * @param keyOf 从条目提取 JSON 字段名的闭包
+     * @param valueOf 从条目提取字段值的闭包
+     * @return 编码后的 [JsonObject]
+     * @author K
+     * @since 1.0.0
+     */
     private inline fun <T> encodeObjectEntries(
         json: Json,
         size: Int,
@@ -226,6 +330,15 @@ internal object JsonFallbackEncoder {
         return JsonObject(encoded)
     }
 
+    /**
+     * 返回 data class 的属性访问器，按主构造器参数顺序在前、其它成员属性在后。
+     * 这样输出的 JSON 字段顺序与源码声明一致，diff 友好。结果按类缓存。
+     *
+     * @param kClass data class 的 KClass
+     * @return 属性访问器列表
+     * @author K
+     * @since 1.0.0
+     */
     private fun getOrderedDataClassProperties(kClass: KClass<*>): List<DataClassPropertyAccessor> {
         return dataClassPropertyCache.getOrPut(kClass) {
             val ctorParamNames = kClass.primaryConstructor?.parameters?.mapNotNull { it.name } ?: emptyList()
@@ -246,6 +359,16 @@ internal object JsonFallbackEncoder {
         }
     }
 
+    /**
+     * 为单个属性构造 [DataClassPropertyAccessor]。
+     * 优先使用 Java getter 反射（更快），失败时退回 Kotlin 反射调用 [KProperty1.get]。
+     *
+     * @param name 属性名
+     * @param prop Kotlin 反射的属性引用
+     * @return 属性访问器
+     * @author K
+     * @since 1.0.0
+     */
     @Suppress("UNCHECKED_CAST")
     private fun buildDataClassPropertyAccessor(
         name: String,

--- a/kudos-base/src/io/kudos/base/data/xls/AbstractExcelImporter.kt
+++ b/kudos-base/src/io/kudos/base/data/xls/AbstractExcelImporter.kt
@@ -34,6 +34,7 @@ import kotlin.reflect.full.primaryConstructor
  */
 abstract class AbstractExcelImporter<T : Any> : IExcelImporter<T> {
 
+    /** 日志器 */
     private val log = LogFactory.getLog(AbstractExcelImporter::class)
 
     /**
@@ -46,8 +47,10 @@ abstract class AbstractExcelImporter<T : Any> : IExcelImporter<T> {
      */
     private lateinit var sheet: Sheet
 
+    /** 属性反射缓存：按属性名缓存 [KProperty1]，避免每行重新反射 */
     private val propertyMap = mutableMapOf<String, KProperty1<T, Any?>>()
 
+    /** 按 Excel 列顺序排列的属性名列表（由 [getPropertyNames] 提供） */
     private lateinit var propertyNames: List<String>
 
     /**
@@ -318,6 +321,15 @@ abstract class AbstractExcelImporter<T : Any> : IExcelImporter<T> {
         return value
     }
 
+    /**
+     * 通过反射解析子类声明的泛型实参 [T]，得到行对象的实际类。
+     * 当子类擦除了泛型实参（解析为 [Nothing]）时立即抛错，避免后续按反射构造对象时静默失败。
+     *
+     * @return 行对象的 [KClass]
+     * @throws IllegalArgumentException 当无法解析泛型实参时
+     * @author K
+     * @since 1.0.0
+     */
     @Suppress("UNCHECKED_CAST")
     private fun resolveRowObjectClass(): KClass<T> {
         val rowObjectClass = GenericKit.getSuperClassGenricClass(this::class)

--- a/kudos-base/src/io/kudos/base/data/xml/XmlKit.kt
+++ b/kudos-base/src/io/kudos/base/data/xml/XmlKit.kt
@@ -54,6 +54,7 @@ import kotlin.reflect.KClass
  */
 object XmlKit {
 
+    /** [JAXBContext] 缓存：按目标 [KClass] 复用，避免重复构建（[JAXBContext] 本身线程安全） */
     private val jaxbContexts = ConcurrentHashMap<KClass<*>, JAXBContext>()
 
     /**
@@ -143,6 +144,19 @@ object XmlKit {
      */
     private fun createUnmarshaller(clazz: KClass<*>): Unmarshaller = getJaxbContext(clazz).createUnmarshaller()
 
+    /**
+     * 获取或创建指定类的 [JAXBContext]。
+     * 同时注册 [CollectionWrapper]，以便处理 Collection 作根元素的情况。
+     *
+     * 注意：当前实现每次都新建 context，再 `putIfAbsent` 写入缓存，
+     * 等于缓存只保留首次构建的实例但仍每次构建一份；后续如需进一步降低开销，
+     * 可改为先查缓存、缺失时再构建。
+     *
+     * @param clazz 目标类
+     * @return 对应的 [JAXBContext]
+     * @author K
+     * @since 1.0.0
+     */
     private fun getJaxbContext(clazz: KClass<*>): JAXBContext {
         val jaxbContext = JAXBContext.newInstance(clazz.java, CollectionWrapper::class.java)
         jaxbContexts.putIfAbsent(clazz, jaxbContext)
@@ -156,6 +170,7 @@ object XmlKit {
      * @since 1.0.0
      */
     class CollectionWrapper(
+        /** 被包装的集合内容；JAXB 通过 `@XmlAnyElement` 自动按元素类型展开输出 */
         @set:XmlAnyElement
         var item: Collection<*>
     )

--- a/kudos-base/src/io/kudos/base/i18n/I18nKit.kt
+++ b/kudos-base/src/io/kudos/base/i18n/I18nKit.kt
@@ -77,6 +77,18 @@ object I18nKit {
         initAll(defaultLocale)
     }
 
+    /**
+     * 按单一类型增量加载国际化资源。
+     * 调用前必须先调用 [initI18n] 完成基础初始化（语言列表、类型列表、默认语言）。
+     *
+     * 加载策略：先加载默认语言，再加载其它语言，最后用默认语言补齐缺失键。
+     *
+     * @param args 可变参数：第 1 个为 type（i18n 子目录名），第 2 个可选为文件名前缀
+     * @return 调用成功固定返回 true，主要表达“已执行”而非校验结果
+     * @throws IllegalStateException 当未先调用 [initI18n] 时
+     * @author K
+     * @since 1.0.0
+     */
     fun initI18nByType(vararg args: String): Boolean {
         if (!::supportLocales.isInitialized || !::types.isInitialized) {
             error("请先调用 initI18n 初始化 I18nKit")
@@ -145,14 +157,17 @@ object I18nKit {
     fun isSupport(locale: String): Boolean = supportLocales.contains(locale)
 
 
+    /** 日志器 */
     private val log = LogFactory.getLog(I18nKit::class)
+    /** 国际化资源根目录（classpath 下） */
     private const val DEFAULT_BASE_PATH = "i18n/"
+    /** 字典国际化的固定类型 key（对应 i18n/dicts/ 子目录） */
     const val DICT_I18N_KEY = "dicts"
 
-    //总的国际化容器: MutableMap<locale, MutableMap<type, MutableMap<module, MutableMap<i18n-key, i18n-value>>>>
+    /** 主国际化容器：locale -> type -> module -> i18nKey -> i18nValue */
     private val i18nMap = mutableMapOf<String, MutableMap<String, MutableMap<String, MutableMap<String, String>>>>()
 
-    //字典国际化容器: MutableMap<locale, MutableMap<type, MutableMap<module, MutableMap<i18n-key, i18n-value>>>>
+    /** 字典专用容器：locale -> module -> dictType -> dictKey -> dictValue */
     private val i18nMapDict =
         mutableMapOf<String, MutableMap<String, MutableMap<String, MutableMap<String, String?>>>>()
 
@@ -161,15 +176,32 @@ object I18nKit {
      */
     private var defaultLocale: String = "zh_CN"
 
+    /** 支持的 locale 集合，由 [initI18n] 注入 */
     private lateinit var supportLocales: Set<String>
 
+    /** 支持的国际化类型集合（i18n 下的子目录名），由 [initI18n] 注入 */
     private lateinit var types: Set<String>
 
+    /**
+     * 入口式初始化：当前仅触发 [initI18n] 完成普通国际化加载。
+     * 字典初始化（[initDictByLocale]）保留为可选扩展点，默认未启用。
+     *
+     * @param defaultLocale 默认语言
+     * @author K
+     * @since 1.0.0
+     */
     private fun initAll(defaultLocale: String) {
         initI18n(defaultLocale)
 //        initDictByLocale(defaultLocale)
     }
 
+    /**
+     * 遍历所有 [types]，按类型分别加载资源；types 为空时只做一次无类型加载。
+     *
+     * @param defaultLocale 默认语言；其余语言会用它补齐缺失键
+     * @author K
+     * @since 1.0.0
+     */
     private fun initI18n(defaultLocale: String) {
         val otherLocales = ArrayList(supportLocales)
         //去除默认语言
@@ -204,6 +236,17 @@ object I18nKit {
         return null
     }
 
+    /**
+     * 加载单一类型下所有语言资源的核心实现。
+     * 先按默认语言完整建立基线，再对其他语言加载并以默认语言补齐缺失键。
+     *
+     * @param type 国际化类型（i18n 子目录名）
+     * @param defaultLocale 默认语言
+     * @param otherLocales 除默认语言之外需要加载的语言列表
+     * @param prefix 资源文件名前缀过滤
+     * @author K
+     * @since 1.0.0
+     */
     private fun initI18nByType(type: String, defaultLocale: String, otherLocales: List<String>, prefix: String) {
         val resources = ClassPathScanner.scanForResources(DEFAULT_BASE_PATH + type, prefix, ".properties")
         val resourceGroup = resourceGroup(resources)
@@ -308,6 +351,16 @@ object I18nKit {
         bundle?.keySet()?.forEach { map[it] = bundle.getString(it) }
     }
 
+    /**
+     * 从资源文件名中解析出模块名与 locale。
+     * 文件名约定：`模块名_两位小写语言代码_两位大写国家代码.properties`。
+     *
+     * @param resource 类路径下的资源
+     * @return Pair(模块名, locale 字符串)
+     * @throws IllegalArgumentException 当文件名不符合命名约定时
+     * @author K
+     * @since 1.0.0
+     */
     private fun getModuleAndLocale(resource: Resource): Pair<String, String> {
         val baseName = resource.filename.substringBefore(".")
         val moduleName = baseName.substring(0, baseName.length - 6)
@@ -315,6 +368,15 @@ object I18nKit {
         return Pair(moduleName, locale)
     }
 
+    /**
+     * 获取或惰性创建指定模块的键值映射。
+     *
+     * @param moduleMap 类型层映射
+     * @param module 模块名
+     * @return 该模块对应的 key->value 映射
+     * @author K
+     * @since 1.0.0
+     */
     private fun createMapByModule(
         moduleMap: MutableMap<String, MutableMap<String, String>>, module: String
     ): MutableMap<String, String> = moduleMap.getOrPut(module) { HashMap() }

--- a/kudos-base/src/io/kudos/base/image/ImageKit.kt
+++ b/kudos-base/src/io/kudos/base/image/ImageKit.kt
@@ -286,6 +286,21 @@ object ImageKit {
         return renderSvgToImage(xmlContent, width, height, false, null, null)
     }
 
+    /**
+     * SVG 渲染的内部实现，支持在渲染前按 id 正则替换颜色填充。
+     * 指定一个临时 URI 是 Batik 解析 SVG 片段引用（如 `#linearGradient1`）的前置条件，
+     * 否则带 URI fragment 的引用会解析失败。
+     *
+     * @param xmlContent SVG 文本
+     * @param width 目标宽度
+     * @param height 目标高度
+     * @param stretch true 时按 X/Y 独立缩放充满，false 时保持比例
+     * @param idRegex 要替换填充色的元素 id 正则，可为 null
+     * @param replacementColor 新的填充色，可为 null
+     * @return 渲染后的位图
+     * @author K
+     * @since 1.0.0
+     */
     private fun renderSvgToImage(
         xmlContent: String,
         width: Int,
@@ -305,6 +320,18 @@ object ImageKit {
         return renderToImage(document, width, height, stretch)
     }
 
+    /**
+     * 用 Batik 把已解析的 [SVGDocument] 渲染为 [BufferedImage]。
+     * 计算 X/Y 缩放比例并按 [stretch] 决定是否保持长宽比；非拉伸时居中输出。
+     *
+     * @param document 已解析的 SVG 文档
+     * @param width 目标位图宽度
+     * @param height 目标位图高度
+     * @param stretch true 时按 X/Y 独立缩放充满，false 时保持比例并居中
+     * @return 渲染后的位图
+     * @author K
+     * @since 1.0.0
+     */
     private fun renderToImage(document: SVGDocument?, width: Int, height: Int, stretch: Boolean): BufferedImage {
         val rendererFactory = ConcreteImageRendererFactory()
         val renderer = rendererFactory.createStaticImageRenderer()
@@ -335,6 +362,17 @@ object ImageKit {
         return renderer.offScreen
     }
 
+    /**
+     * 遍历文档中所有 SVG 元素，对 id 匹配 [idRegex] 的元素，
+     * 将其 `style` 属性中的 `fill:#XXXXXX` 替换为指定颜色。
+     * 仅修改 style 内联属性，不处理 CSS 类或外部样式表。
+     *
+     * @param document SVG 文档
+     * @param idRegex 目标元素 id 的正则
+     * @param color 新的填充色
+     * @author K
+     * @since 1.0.0
+     */
     private fun replaceFill(document: SVGDocument, idRegex: String, color: Color) {
         val colorCode = String.format("#%02x%02x%02x", color.red, color.green, color.blue)
         val children = document.getElementsByTagName("*")

--- a/kudos-base/src/io/kudos/base/image/barcode/QrCodeKit.kt
+++ b/kudos-base/src/io/kudos/base/image/barcode/QrCodeKit.kt
@@ -20,7 +20,7 @@ import javax.imageio.ImageIO
  */
 object QrCodeKit {
 
-    // 二维码写码器
+    /** ZXing 二维码写码器，[MultiFormatWriter] 线程安全可单例复用 */
     private val mutiWriter = MultiFormatWriter()
 
     /**

--- a/kudos-base/src/io/kudos/base/io/FileKit.kt
+++ b/kudos-base/src/io/kudos/base/io/FileKit.kt
@@ -31,6 +31,7 @@ object FileKit {
      */
     const val PREFIX_TEMP_FILE: String = "FileKit_"
 
+    /** 日志器 */
     private val log = LogFactory.getLog(this::class)
 
     /**

--- a/kudos-base/src/io/kudos/base/io/PathKit.kt
+++ b/kudos-base/src/io/kudos/base/io/PathKit.kt
@@ -168,6 +168,19 @@ object PathKit {
      */
     fun getUserDirectory(): File = FileUtils.getUserDirectory()
 
+    /**
+     * 把非 `file:` 协议下的资源（如 `jar:`、`jrt:`）抽取到一个新建的临时目录中，
+     * 让上层调用方可以拿到一个可读的本地路径。临时目录与文件都注册 [File.deleteOnExit]。
+     *
+     * 单独创建专用子目录而不是直接复制到系统 temp 根目录，是为了避免与其他工具
+     * 在 temp 根目录扫描时踩权限/竞态问题。
+     *
+     * @param url 资源 URL
+     * @param name 资源原始名（仅用于命名临时文件，空白名会回退到 `resource.bin`）
+     * @return 抽取后的临时文件路径
+     * @author K
+     * @since 1.0.0
+     */
     private fun extractToTempDir(url: URL, name: String): Path {
         // 关键：用“专用临时目录”，避免把系统 temp 根目录整个复制/扫描时踩权限坑
         val dir = Files.createTempDirectory("resource-").toFile().apply { deleteOnExit() }

--- a/kudos-base/src/io/kudos/base/io/scanner/classpath/ClassPathScanner.kt
+++ b/kudos-base/src/io/kudos/base/io/scanner/classpath/ClassPathScanner.kt
@@ -70,6 +70,7 @@ import kotlin.reflect.KClass
  */
 object ClassPathScanner {
     
+    /** 日志器；扫描失败仅记日志、不抛出 */
     private val logger = LogFactory.getLog(this::class)
 
     /**

--- a/kudos-base/src/io/kudos/base/lang/PackageKit.kt
+++ b/kudos-base/src/io/kudos/base/lang/PackageKit.kt
@@ -18,6 +18,7 @@ import kotlin.reflect.KClass
  */
 object PackageKit {
 
+    /** 日志器 */
     private val LOG = LogFactory.getLog(PackageKit::class)
 
     /**
@@ -54,6 +55,15 @@ object PackageKit {
         return pkgs.filter { it.matches(Regex(regExp)) }.toSet()
     }
 
+    /**
+     * 从含通配符的包正则中提取“可枚举的固定前缀”。
+     * 把 `io.kudos.*.bean` 这样的输入截取到第一个含 `*` 段之前，得到 `io.kudos`。
+     *
+     * @param pkgPattern 含 `*` 的包匹配表达式
+     * @return 去掉末尾点号的固定前缀
+     * @author K
+     * @since 1.0.0
+     */
     private fun getPackagePrefix(pkgPattern: String): String {
         val pkgPrefix = StringBuilder()
         val pkgElems = pkgPattern.split(".").toTypedArray()
@@ -67,6 +77,16 @@ object PackageKit {
         return pkgPrefix.deleteCharAt(pkgPrefix.length - 1).toString()
     }
 
+    /**
+     * 包扫描的统一入口：对当前线程的 classloader 拿到所有匹配资源，
+     * 按协议分发到“文件目录扫描”或“JAR 扫描”。结果写入 [action]。
+     *
+     * @param packagePrefix 固定包前缀（点号分隔），不能含通配符
+     * @param recursive 是否递归扫描子目录
+     * @param action 扫描结果收集器
+     * @author K
+     * @since 1.0.0
+     */
     private fun find(packagePrefix: String, recursive: Boolean, action: Action) {
         // 获取包的名字 并进行替换
         val packageDirName = packagePrefix.replace('.', '/')
@@ -97,6 +117,19 @@ object PackageKit {
         }
     }
 
+    /**
+     * 以 JAR 形式扫描指定包前缀，把命中的类或子包收集到 [action]。
+     * 根据 [Action.isRetrieveClass] 切换“收类”或“收包”行为；
+     * recursive=false 时只收顶层包/类。
+     *
+     * @param packageName 入参与递归过程中维护的当前包名
+     * @param packageDirName 包前缀的目录形式（点号转斜杠）
+     * @param url JAR 对应的资源 URL
+     * @param recursive 是否递归扫描
+     * @param action 扫描结果收集器
+     * @author K
+     * @since 1.0.0
+     */
     private fun findAndAddClassesInPackageByJar(
         packageName: String, packageDirName: String, url: URL, recursive: Boolean, action: Action
     ) {
@@ -202,15 +235,34 @@ object PackageKit {
         }
     }
 
+    /**
+     * 包扫描内部收集器。
+     * true 时把命中的类放入 [classes]；false 时把命中的子包放入 [pkgs]，
+     * 通过同一套扫描代码服务于 [getClassesInPackage] 与 [getPackages] 两个公开入口。
+     *
+     * @author K
+     * @since 1.0.0
+     */
     private class Action(retrieveClass: Boolean) {
+        /** true: 当前扫描在收集类；false: 当前扫描在收集子包 */
         var isRetrieveClass = true
+        /** 命中的类，使用 [LinkedHashSet] 保证发现顺序 */
         val classes = LinkedHashSet<KClass<*>>()
+        /** 命中的子包名，使用 [LinkedHashSet] 保证发现顺序 */
         val pkgs = LinkedHashSet<String>()
 
+        /**
+         * 收集一个类。
+         * @param clazz 命中的类
+         */
         fun addClass(clazz: KClass<*>) {
             classes.add(clazz)
         }
 
+        /**
+         * 收集一个子包名。
+         * @param pkg 命中的包名
+         */
         fun addPackage(pkg: String) {
             pkgs.add(pkg)
         }

--- a/kudos-base/src/io/kudos/base/lang/SystemKit.kt
+++ b/kudos-base/src/io/kudos/base/lang/SystemKit.kt
@@ -21,6 +21,7 @@ import java.util.regex.Pattern
  */
 object SystemKit {
 
+    /** 日志器 */
     private val log = LogFactory.getLog(this::class)
 
     /**
@@ -74,6 +75,18 @@ object SystemKit {
         }
     }
 
+    /**
+     * 通过反射往 `MutableMap<String, String>` 中写入新的键值。
+     * 与 [setEnvVars] 配合：先 [clearFirst] 清空再 putAll，或保留原值后增量 putAll。
+     * 任何反射失败、键值类型不匹配或方法签名不符都返回 false，由上层兜底。
+     *
+     * @param target 反射拿到的 map 引用，可能为 null
+     * @param vars 待写入的键值
+     * @param clearFirst 是否在写入前先调用 map.clear()
+     * @return 写入成功返回 true，否则 false
+     * @author K
+     * @since 1.0.0
+     */
     private fun updateMutableStringMap(target: Any?, vars: Map<String, String>, clearFirst: Boolean): Boolean {
         val map = target as? MutableMap<*, *> ?: return false
         if (!map.keys.all { it is String } || !map.values.all { it is String }) {
@@ -137,6 +150,15 @@ object SystemKit {
         return success to message
     }
 
+    /**
+     * 把 [Process] 的输出流按 UTF-8 默认字符集读到一个字符串。
+     * 读取完成后自动关闭流，非空字符串会追加一个换行符以贴近终端输出习惯。
+     *
+     * @param inputStream 进程标准输出或标准错误流
+     * @return 读取到的文本；流为空时返回空串
+     * @author K
+     * @since 1.0.0
+     */
     private fun loadStream(inputStream: InputStream): String {
         inputStream.use { stream ->
             BufferedReader(InputStreamReader(stream)).use { reader ->
@@ -188,6 +210,7 @@ object SystemKit {
      */
     val LINE_SEPARATOR: String = System.lineSeparator()
 
+    /** 用于在 JVM 启动参数中识别调试模式（`-Xdebug` 或 `jdwp`）的正则 */
     private val debugPattern = Pattern.compile("-Xdebug|jdwp")
 
     /**

--- a/kudos-base/src/io/kudos/base/net/IpKit.kt
+++ b/kudos-base/src/io/kudos/base/net/IpKit.kt
@@ -18,9 +18,10 @@ import java.util.Locale
  */
 object IpKit {
 
+    /** 日志器 */
     private val LOG = LogFactory.getLog(this::class)
 
-    // 二进制32位为全1的整数值
+    /** 32 位无符号最大值（即 2³²-1），用于 IPv4 长整型范围校验 */
     private const val ALL32ONE = 4294967295L
 
     /** 128 位无符号最大值（含），与 `NUMERIC(39,0)` 存 IPv6 整值时一致。 */
@@ -375,6 +376,15 @@ object IpKit {
         }
     }
 
+    /**
+     * 以 IPv6 优先的策略将文本解析为存储用 `BigDecimal`：
+     * 先尝试 [toFullIpv6] + [fullIpv6ColonGroupsTextToUnsignedDecimal]；失败时按十进制串兜底。
+     *
+     * @param s 已 trim 的输入文本
+     * @return 解析结果，无法解析时返回 null
+     * @author K
+     * @since 1.0.0
+     */
     private fun parseIpv6PreferToDecimal(s: String): BigDecimal? {
         return runCatching {
             val full = toFullIpv6(s)
@@ -384,6 +394,15 @@ object IpKit {
         }
     }
 
+    /**
+     * 以 IPv4 优先的策略将文本解析为存储用 `BigDecimal`：
+     * 纯数字串直接当十进制处理；否则按点分/定长 IPv4 经 [ipv4DottedOrFixedToUnsignedDecimal] 转换。
+     *
+     * @param s 已 trim 的输入文本
+     * @return 解析结果，无法解析时返回 null
+     * @author K
+     * @since 1.0.0
+     */
     private fun parseIpv4PreferToDecimal(s: String): BigDecimal? {
         return when {
             s.all { it.isDigit() } -> runCatching { BigDecimal(s) }.getOrNull()
@@ -391,6 +410,15 @@ object IpKit {
         }
     }
 
+    /**
+     * 把点分（含定长零补齐）形式 IPv4 转为存储用 `BigDecimal`：
+     * 先归一为非定长 IPv4 文本；归一失败时按十进制串兜底；归一成功后将无符号 32 位整数包成 `BigDecimal` 返回。
+     *
+     * @param s 输入文本
+     * @return 转换结果，[ipv4StringToLong] 返回 -1 时返回 null
+     * @author K
+     * @since 1.0.0
+     */
     private fun ipv4DottedOrFixedToUnsignedDecimal(s: String): BigDecimal? {
         var normal = getNormalIpv4(s)
         if (normal.isEmpty()) {
@@ -402,6 +430,15 @@ object IpKit {
         return if (l < 0) null else BigDecimal(BigInteger.valueOf(l and 0xFFFFFFFFL))
     }
 
+    /**
+     * 自动判定输入类型并解析为存储用 `BigDecimal`：
+     * 优先级 — 纯十进制串 > 合法 IPv4 > 合法 IPv6 > 兜底按十进制串。
+     *
+     * @param s 已 trim 的输入文本
+     * @return 解析结果，全部尝试失败时返回 null
+     * @author K
+     * @since 1.0.0
+     */
     private fun parseAutoToDecimal(s: String): BigDecimal? {
         return when {
             s.all { it.isDigit() } -> runCatching { BigDecimal(s) }.getOrNull()

--- a/kudos-base/src/io/kudos/base/net/http/HttpClientKit.kt
+++ b/kudos-base/src/io/kudos/base/net/http/HttpClientKit.kt
@@ -219,10 +219,28 @@ object HttpClientKit {
         return response.await()
     }
 
+    /**
+     * 将 [HttpRequest.Builder] 转为不可变 [HttpRequest]。
+     * 独立成一个函数主要便于后续插入埋点、追加默认 header 等扩展，目前为薄包装。
+     *
+     * @param httpRequestBuilder 请求构建器
+     * @return 构建完成的请求
+     * @author K
+     * @since 1.0.0
+     */
     private fun createHttpRequest(httpRequestBuilder: HttpRequest.Builder): HttpRequest {
         return httpRequestBuilder.build()
     }
 
+    /**
+     * 将 [HttpClient.Builder] 转为 [HttpClient]。
+     * 独立成一个函数便于后续替换为注入式的客户端工厂（例如统一注入连接池、证书校验策略）。
+     *
+     * @param httpClientBuilder 客户端构建器
+     * @return 构建完成的客户端
+     * @author K
+     * @since 1.0.0
+     */
     private fun createHttpClient(httpClientBuilder: HttpClient.Builder): HttpClient {
         return httpClientBuilder.build()
     }
@@ -531,8 +549,11 @@ object HttpClientKit {
      * 一个轻量的 HttpResponse 包装，让我们能够“更改 body 为 Path”并沿用原响应的状态码/头（若有）。
      */
     private class FakeHttpResponse(
+        /** body 替换为最终落盘路径 */
         private val path: Path,
+        /** 自定义状态码，如本地命中已存在文件时用 200 */
         private val code: Int,
+        /** 原始响应；用于代理 headers/uri/version 等元信息，可为 null（构造伪响应时） */
         private val delegate: HttpResponse<*>? = null
     ) : HttpResponse<Path> {
 

--- a/kudos-base/src/io/kudos/base/query/enums/OperatorEnum.kt
+++ b/kudos-base/src/io/kudos/base/query/enums/OperatorEnum.kt
@@ -358,6 +358,16 @@ enum class OperatorEnum(
         }
     }
 
+    /**
+     * 通用比较：对常见基础类型（Number、String、Char、Boolean）走专用路径，
+     * 其余按反射查找目标类型可接受 right 的 `compareTo` 方法。
+     *
+     * @param left 左值，null 时直接返回 null
+     * @param right 右值，null 时直接返回 null
+     * @return 标准比较结果（负数/0/正数），无法比较返回 null
+     * @author K
+     * @since 1.0.0
+     */
     private fun compareComparableValues(left: Any?, right: Any?): Int? {
         if (left == null || right == null) {
             return null
@@ -378,6 +388,16 @@ enum class OperatorEnum(
         return runCatching { compareToMethod.invoke(left, right) as? Int }.getOrNull()
     }
 
+    /**
+     * 反射查找 `leftClass` 上能接受 `rightClass` 作为参数的 `compareTo` 方法。
+     * 结果按 (leftClass, rightClass) 进缓存，避免每次比较都遍历方法表。
+     *
+     * @param leftClass 左值类型
+     * @param rightClass 右值类型
+     * @return 找到的方法；找不到返回 null
+     * @author K
+     * @since 1.0.0
+     */
     private fun getCompareToMethod(leftClass: Class<*>, rightClass: Class<*>): Method? {
         val cacheKey = MethodCacheKey(leftClass, rightClass)
         compareToMethodCache[cacheKey]?.let { return it }
@@ -390,6 +410,15 @@ enum class OperatorEnum(
         return method
     }
 
+    /**
+     * 数值比较：同类型直接走原生 compareTo，异类型统一升到 [BigDecimal] 比较以避免精度丢失。
+     *
+     * @param left 左数
+     * @param right 右数
+     * @return 标准比较结果；[BigDecimal] 解析失败时返回 null
+     * @author K
+     * @since 1.0.0
+     */
     private fun compareNumbers(left: Number, right: Number): Int? {
         return when {
             left is Int && right is Int -> left.compareTo(right)
@@ -473,9 +502,20 @@ enum class OperatorEnum(
     }
 
     companion object Companion {
+        /** 缓存 `compareTo` 方法时使用的 (leftClass, rightClass) 复合键 */
         private data class MethodCacheKey(val leftClass: Class<*>, val rightClass: Class<*>)
+        /** 反射查找到的 `compareTo` 方法缓存 */
         private val compareToMethodCache = ConcurrentHashMap<MethodCacheKey, Method>()
 
+        /**
+         * 按操作符 code 解析为枚举（大小写不敏感）。
+         *
+         * @param code 操作符 code，如 `=`、`>=`、`LIKE`
+         * @return 匹配的枚举
+         * @throws IllegalStateException 当 code 不合法时
+         * @author K
+         * @since 1.0.0
+         */
         fun enumOf(code: String): OperatorEnum {
             var operatorCode = code
             if (operatorCode.isNotBlank()) {

--- a/kudos-base/src/io/kudos/base/security/Base36Kit.kt
+++ b/kudos-base/src/io/kudos/base/security/Base36Kit.kt
@@ -27,6 +27,7 @@ import java.util.Locale
  */
 object Base36Kit {
 
+    /** 默认加密 Key（18 位正整数），未显式传入 key 时使用 */
     const val KEY = 999966699996669999L
 
     /**
@@ -138,6 +139,20 @@ object Base36Kit {
         return deOutOrder(srcString, key)
     }
 
+    /**
+     * 按 key 对源字符串做“乱序”：
+     * 1. 先按 (key % 100 % len) 做循环左移；
+     * 2. 用 key 的每一位生成排序权重，对前 min(srcLen, keyLen) 个字符按权重重排；
+     * 3. 超出 key 长度的尾部字符保持移位后的相对顺序。
+     *
+     * 与 [deOutOrder] 严格互逆。
+     *
+     * @param src 待乱序的字符串
+     * @param key 加密 Key
+     * @return 乱序后的字符串
+     * @author K
+     * @since 1.0.0
+     */
     private fun outOrder(src: String, key: Long): String {
         var srcString = src
         val keyStr = key.toString()
@@ -170,6 +185,16 @@ object Base36Kit {
         return targStr
     }
 
+    /**
+     * [outOrder] 的逆运算：先按 key 权重排序得到位置映射，
+     * 再把密文字符放回原位置，最后做反向循环移位，恢复原始字符串。
+     *
+     * @param srcString 已乱序的字符串
+     * @param key 加密 Key（须与加密时相同）
+     * @return 恢复原顺序后的字符串
+     * @author K
+     * @since 1.0.0
+     */
     private fun deOutOrder(srcString: String, key: Long): String {
         val keyStr = key.toString()
         //String[] keyArr = keyStr.split("");
@@ -207,7 +232,16 @@ object Base36Kit {
         return targStr
     }
 
-    //数组排序
+    /**
+     * 对二维字符串数组按指定列做升序冒泡排序（原地修改）。
+     * 排序键为字符串解析后的整型，列值为空会触发 [IllegalArgumentException]。
+     *
+     * @param arr 待排序数组，行表示元素，列表示属性
+     * @param col 用于比较大小的列下标
+     * @return 排序完成的数组（与入参为同一引用）
+     * @author K
+     * @since 1.0.0
+     */
     private fun sortArr(arr: Array<Array<String?>>, col: Int): Array<Array<String?>> {
         var temp: Array<String?>
         for (i in 0 until arr.size - 1) {
@@ -224,7 +258,19 @@ object Base36Kit {
         return arr
     }
 
-    //字符串转换
+    /**
+     * 在自定义编码（36 进制或 62 进制）空间内对字符串前缀做加法/减法位移。
+     * 流程：ASCII -> 自定义编码 -> 加或减 key 的对应位 -> 回到 ASCII。
+     * band36=true 时小写字母按大写处理，保证“纯大写+数字”输入输出仍为纯大写+数字。
+     *
+     * @param inStr 待转换的字符串
+     * @param transNum 用于位移的数字（即加密 Key）
+     * @param plusMinus true 代表加密（加法），false 代表解密（减法）
+     * @param band36 true 走 36 进制（仅大写+数字），false 走 62 进制（含小写）
+     * @return 转换后的字符串
+     * @author K
+     * @since 1.0.0
+     */
     private fun transStr(inStr: String, transNum: Long, plusMinus: Boolean, band36: Boolean): String {
         var s = inStr
         var band = 62
@@ -256,7 +302,16 @@ object Base36Kit {
         return String(ch)
     }
 
-    //按自定义的36位或/62位编码重新编码，0~9为数字，10~35为大写字母，36~51位为小写字母
+    /**
+     * 把 ASCII 编码映射到自定义紧凑编码：
+     * 数字 `0-9` -> 0..9，大写字母 `A-Z` -> 10..35，小写字母 `a-z` -> 36..61，
+     * 其余字符保持原值不变。
+     *
+     * @param codeNum 输入字符的 ASCII 码
+     * @return 自定义编码值
+     * @author K
+     * @since 1.0.0
+     */
     private fun asciiToDiy(codeNum: Int): Int { //如果n的ASCII码在48~57，则n是数字, 65~90则是大写字母
         return when(codeNum) {
             in 48..57 -> codeNum - 48
@@ -266,7 +321,16 @@ object Base36Kit {
         }
     }
 
-    //把自定义的36位或/62位编码重新转为ASCII码，0~9为数字，10~35为大写字母，36~51位为小写字母
+    /**
+     * [asciiToDiy] 的逆映射：把自定义紧凑编码映射回 ASCII。
+     * 注意：减法位运算可能让 codeNum 临时为 -1（band 取模溢出），
+     * 此时落入 `-1..9` 分支映射为数字 `0-9` 区段，保持互逆。
+     *
+     * @param codeNum 自定义编码值
+     * @return 对应的 ASCII 码
+     * @author K
+     * @since 1.0.0
+     */
     private fun diyToAscii(codeNum: Int): Int { //把自定义编码转回ASCII码
         return when(codeNum) {
             in -1..9 -> codeNum + 48
@@ -276,6 +340,15 @@ object Base36Kit {
         }
     }
 
+    /**
+     * 计算字符串的 MD5 摘要并返回大写十六进制字符串。
+     * 仅用于在加密结果头部生成 1 位校验位，不作通用安全用途。
+     *
+     * @param s 待摘要的字符串
+     * @return 32 位大写十六进制 MD5；JDK 不支持 MD5 算法时返回 null
+     * @author K
+     * @since 1.0.0
+     */
     private fun getMD5(s: String): String? {
         val hexDigits =
             charArrayOf('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F')

--- a/kudos-base/src/io/kudos/base/security/CryptoKit.kt
+++ b/kudos-base/src/io/kudos/base/security/CryptoKit.kt
@@ -24,32 +24,45 @@ import javax.crypto.spec.SecretKeySpec
  */
 object CryptoKit {
 
+    /** 日志器，用于在兼容路径上记录降级解密失败等告警信息 */
     private val logger = LogFactory.getLog(this::class)
 
+    /** AES 算法名 */
     private const val AES_ALGORITHM = "AES"
     /** 与历史 `Cipher.getInstance("AES")` 行为一致，显式写出便于审阅。 */
     private const val AES_ECB_TRANSFORM = "AES/ECB/PKCS5Padding"
+    /** AES-GCM 认证加密变换名，无填充 */
     private const val AES_GCM_TRANSFORM = "AES/GCM/NoPadding"
+    /** HMAC-SHA1 算法名 */
     private const val HMACSHA1 = "HmacSHA1"
+    /** 触发“密文大小写翻转”的密钥前缀（向后兼容老约定） */
     private const val HTB = "_HTB"
 
+    /** [aesEncrypt]/[aesDecrypt] 无参形式使用的密文标记前缀，用于区分历史明文与加密内容 */
     private const val PREFIX = "┼"
+    /** 字符串与字节互转使用的字符集 */
     private const val CHARSET = "UTF-8"
 
+    /** HMAC-SHA1 默认密钥长度（RFC2401 建议值） */
     private const val DEFAULT_HMACSHA1_KEYSIZE = 160 // RFC2401
 
+    /** [generateIV] 生成的随机 IV 默认字节数（与 AES 块大小一致） */
     private const val DEFAULT_IVSIZE = 16
 
     /** 新格式密文前缀：ASCII 「GCM」+ 版本字节 0x01。 */
     private val AES_GCM_MAGIC = byteArrayOf(0x47, 0x43, 0x4D, 0x01)
 
+    /** GCM 模式 IV 长度（NIST 推荐 12 字节） */
     private const val GCM_IV_LENGTH = 12
+    /** GCM 认证标签长度（比特），128 位为标准长度 */
     private const val GCM_TAG_LENGTH_BITS = 128
 
+    /** Hex 编码使用的小写字符表 */
     private val DIGITS = charArrayOf(
         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
     )
 
+    /** 强随机源，用于 IV 与密钥生成 */
     private val random = SecureRandom()
 
     //-- HMAC-SHA1 function --//
@@ -140,6 +153,16 @@ object CryptoKit {
         }
     }
 
+    /**
+     * 使用 AES-128-GCM 对明文加密。
+     * 每次随机生成 12 字节 IV，输出格式为 `AES_GCM_MAGIC || IV || ciphertext+tag`。
+     *
+     * @param plain 待加密明文字节
+     * @param password 密码字节，将通过 [buildAesKey] 派生为 128 位密钥
+     * @return 带魔数前缀与 IV 的密文字节数组
+     * @author K
+     * @since 1.0.0
+     */
     private fun aesGcmEncrypt(plain: ByteArray, password: ByteArray): ByteArray {
         val iv = ByteArray(GCM_IV_LENGTH)
         random.nextBytes(iv)
@@ -149,6 +172,17 @@ object CryptoKit {
         return AES_GCM_MAGIC + iv + ct
     }
 
+    /**
+     * 解密由 [aesGcmEncrypt] 产生的 GCM 密文。
+     * 期望输入开头匹配 [AES_GCM_MAGIC]，紧随 12 字节 IV，再是密文与认证标签。
+     *
+     * @param input 含魔数与 IV 的 GCM 密文
+     * @param password 密码字节，须与加密时相同
+     * @return 解密后的明文字节数组
+     * @throws IllegalArgumentException 当输入长度不足以包含魔数与 IV 时
+     * @author K
+     * @since 1.0.0
+     */
     private fun aesGcmDecrypt(input: ByteArray, password: ByteArray): ByteArray {
         val headerLen = AES_GCM_MAGIC.size + GCM_IV_LENGTH
         require(input.size > headerLen) { "Invalid AES-GCM payload length" }
@@ -159,12 +193,34 @@ object CryptoKit {
         return cipher.doFinal(ct)
     }
 
+    /**
+     * AES/ECB/PKCS5Padding 的加解密（旧格式兼容路径）。
+     * 仅用于读取历史数据，不应再用于新数据加密。
+     *
+     * @param input 待处理数据
+     * @param password 密码字节，将通过 [buildAesKey] 派生为 128 位密钥
+     * @param mode [Cipher.ENCRYPT_MODE] 或 [Cipher.DECRYPT_MODE]
+     * @return 处理后的字节数组
+     * @author K
+     * @since 1.0.0
+     */
     private fun aesEcb(input: ByteArray, password: ByteArray, mode: Int): ByteArray {
         val cipher = Cipher.getInstance(AES_ECB_TRANSFORM)
         cipher.init(mode, buildAesKey(password))
         return cipher.doFinal(input)
     }
 
+    /**
+     * 最旧版本派生密钥路径：通过 SHA1PRNG 以 password 作种子生成 128 位密钥。
+     * 仅在 [aesEcb] 直接解密失败时降级使用，用于读取最早的存量密文。
+     *
+     * @param input 待解密数据
+     * @param password 密码字节，作为 SHA1PRNG 的种子
+     * @param mode [Cipher.ENCRYPT_MODE] 或 [Cipher.DECRYPT_MODE]
+     * @return 处理后的字节数组
+     * @author K
+     * @since 1.0.0
+     */
     private fun aesLegacy(input: ByteArray, password: ByteArray, mode: Int): ByteArray {
         val generator = KeyGenerator.getInstance(AES_ALGORITHM)
         val secureRandom = SecureRandom.getInstance("SHA1PRNG")
@@ -175,6 +231,15 @@ object CryptoKit {
         return cipher.doFinal(input)
     }
 
+    /**
+     * 通过 SHA-256 对密码做一次摘要并截取前 16 字节作为 AES-128 密钥。
+     * 既保证密钥长度合法，也避免直接暴露密码字节。
+     *
+     * @param password 原始密码字节
+     * @return 可直接喂给 [Cipher.init] 的 AES 密钥
+     * @author K
+     * @since 1.0.0
+     */
     private fun buildAesKey(password: ByteArray): SecretKeySpec {
         val digest = MessageDigest.getInstance("SHA-256").digest(password)
         val key = digest.copyOf(16) // AES-128
@@ -302,6 +367,15 @@ object CryptoKit {
         return arrOut
     }
 
+    /**
+     * 把单字节 ASCII 十六进制字符（`0-9` `a-f` `A-F`）转为 0..15 的整数。
+     *
+     * @param b ASCII 十六进制字符的字节表示
+     * @return 该字符对应的十进制值
+     * @throws NumberFormatException 当字节不是合法的十六进制字符时
+     * @author K
+     * @since 1.0.0
+     */
     private fun hexNibble(b: Byte): Int {
         val c = b.toInt() and 0xFF
         return when {

--- a/kudos-base/src/io/kudos/base/security/DigestKit.kt
+++ b/kudos-base/src/io/kudos/base/security/DigestKit.kt
@@ -15,9 +15,12 @@ import java.security.SecureRandom
  */
 object DigestKit {
 
+    /** SHA-1 算法名 */
     const val SHA1 = "SHA-1"
+    /** MD5 算法名 */
     const val MD5 = "MD5"
 
+    /** 强随机源，用于生成 salt */
     private val random = SecureRandom()
 
     //region MD5
@@ -131,6 +134,16 @@ object DigestKit {
 
     //endregion
 
+    /**
+     * 对流式输入做摘要，按 8KB 分块读取，避免一次性加载大文件到内存。
+     * 不会关闭传入的流，关闭责任由调用方承担。
+     *
+     * @param input 输入流
+     * @param algorithm 算法名（[SHA1] 或 [MD5]）
+     * @return 摘要字节数组
+     * @author K
+     * @since 1.0.0
+     */
     private fun digest(input: InputStream, algorithm: String): ByteArray {
         val messageDigest = MessageDigest.getInstance(algorithm)
         val bufferLength = 8 * 1024

--- a/kudos-base/src/io/kudos/base/security/GoogleAuthenticator.kt
+++ b/kudos-base/src/io/kudos/base/security/GoogleAuthenticator.kt
@@ -15,6 +15,10 @@ import kotlin.experimental.and
  * @since 1.0.0
  */
 class GoogleAuthenticator {
+    /**
+     * TOTP 验证时允许的“时间窗口”半径（每个窗口 30 秒）。
+     * 默认 3 表示前后各允许 3 个窗口的时钟漂移；Google 文档建议最大值 17。
+     */
     var windowSize = 3 // default 3 - max 17 (from google docs)最多可偏移的时间
 
         /**
@@ -62,8 +66,11 @@ class GoogleAuthenticator {
 
     companion object {
         // taken from Google pam docs - we probably don't need to mess with these
+        /** 共享密钥的字节长度（来自 Google pam 推荐值），Base32 编码后约 16 字符 */
         const val SECRET_SIZE = 10
+        /** SecureRandom 的初始化种子（Base64 编码），用于派生密钥生成器 */
         const val SEED = "g8GjEvTbW5oVSV7avLBdwIHqGlUYNzKFI7izOF8GwLDVKs2m0QN7vxRs2im5MDaNCWGmcD2rvcZx"
+        /** 随机数发生器算法名 */
         const val RANDOM_NUMBER_ALGORITHM = "SHA1PRNG"
 
         /**
@@ -103,6 +110,19 @@ class GoogleAuthenticator {
             return String.format(format, user, host, secret)
         }
 
+        /**
+         * 按 RFC 6238 (TOTP) / RFC 4226 (HOTP) 计算指定时间窗口的 6 位动态码。
+         *
+         * 关键细节：`hash[i]` 直接 `toLong()` 会做符号扩展，必须先 `toInt() and 0xFF`
+         * 拼成无符号字节，否则当某个字节 ≥ 0x80 时上位会被污染，最终得出的数字
+         * 会与 Google Authenticator / Authy / 1Password 等标准客户端不一致。
+         *
+         * @param key 已经解码的共享密钥
+         * @param t 当前时间窗口序号（毫秒 / 1000 / 30）
+         * @return 6 位整数动态码（0..999999）
+         * @throws NoSuchAlgorithmException 当前 JDK 不支持 HmacSHA1 时
+         * @throws InvalidKeyException 密钥不可用于 HmacSHA1 初始化时
+         */
         @Throws(NoSuchAlgorithmException::class, InvalidKeyException::class)
         internal fun verifyCode(key: ByteArray, t: Long): Int {
             val data = ByteArray(8)

--- a/kudos-base/src/io/kudos/base/support/service/impl/BaseCrudService.kt
+++ b/kudos-base/src/io/kudos/base/support/service/impl/BaseCrudService.kt
@@ -127,9 +127,11 @@ open class BaseCrudService<PK : Any, E : IIdEntity<PK>, DAO : IBaseCrudDao<PK, E
         entityClass.memberProperties.first { it.name == IHasBuiltIn::builtIn.name } as KProperty1<E, Boolean?>
     }
 
+    /** 实体主键属性名（取自 [IIdEntity.id]，避免在条件构造中硬编码字符串） */
     private val idPropertyName: String
         get() = IIdEntity<PK>::id.name
 
+    /** 内置标记属性名（取自 [IHasBuiltIn.builtIn]，避免在条件构造中硬编码字符串） */
     private val builtInPropertyName: String
         get() = IHasBuiltIn::builtIn.name
 
@@ -141,6 +143,14 @@ open class BaseCrudService<PK : Any, E : IIdEntity<PK>, DAO : IBaseCrudDao<PK, E
     private fun builtInTrueCriteria(): Criteria =
         Criteria.of(builtInPropertyName, OperatorEnum.EQ, true)
 
+    /**
+     * 统一抛出“内置行不可删除”的业务异常。
+     * 写成 [Nothing] 返回类型让调用处的类型推断保留 if/else 中另一分支的具体类型。
+     *
+     * @throws ServiceException 总是抛出，errorCode 为 [CommonErrorCodeEnum.BUILTIN_NOT_DELETABLE]
+     * @author K
+     * @since 1.0.0
+     */
     private fun throwBuiltInNotDeletable(): Nothing =
         throw ServiceException(CommonErrorCodeEnum.BUILTIN_NOT_DELETABLE)
 


### PR DESCRIPTION
Across 28 worst-offender files in kudos-base, fill in missing KDoc on class declarations, private helpers, reflection caches, and nested data classes so the "why" is captured next to the code (e.g. GCM-vs-ECB fallback, SHA1PRNG legacy key derivation, Annotation cache-key relying on JDK content-equality, Hibernate validator's two-arg initialize needed to avoid PatternValidator NPE, IPv6 BigInteger matching NUMERIC(39,0) storage).