### PR TITLE
docs(ms): backfill KDoc on private helpers across ms-sys/ms-user serv…

### DIFF
--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/src/io/kudos/ms/auth/core/platform/enums/dict/AuthModuleEnum.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/src/io/kudos/ms/auth/core/platform/enums/dict/AuthModuleEnum.kt
@@ -2,6 +2,16 @@ package io.kudos.ms.auth.core.platform.enums.dict
 
 import io.kudos.base.enums.ienums.IModuleEnum
 
+/**
+ * 鉴权服务的模块枚举占位。
+ *
+ * 实现 [IModuleEnum]、目前**无任何成员**——保留只为对接框架对 `IModuleEnum` SPI 的扫描契约
+ * （字典 / 日志 / 权限组件会按 `IModuleEnum` 子类型聚合分类）。后续 auth 子系统拆出更细粒度的
+ * 模块时（如 `ROLE` / `GROUP` / `PERMISSION`）在此追加枚举值即可，避免散落在各处自创 enum。
+ *
+ * @author K
+ * @since 1.0.0
+ */
 enum class AuthModuleEnum : IModuleEnum {
 
 

--- a/kudos-ms/kudos-ms-sys/kudos-ms-sys-core/src/io/kudos/ms/sys/core/accessrule/service/impl/SysAccessRuleIpService.kt
+++ b/kudos-ms/kudos-ms-sys/kudos-ms-sys-core/src/io/kudos/ms/sys/core/accessrule/service/impl/SysAccessRuleIpService.kt
@@ -184,6 +184,15 @@ open class SysAccessRuleIpService(
         }
     }
 
+    /**
+     * 从 update 入参抽 id；要求实现 [IIdEntity] 且 id 是 String。
+     *
+     * @param any 更新入参
+     * @return IP 访问规则 id
+     * @throws IllegalStateException 入参类型不被支持
+     * @author K
+     * @since 1.0.0
+     */
     private fun requireIpRuleId(any: Any): String =
         (any as? IIdEntity<*>)?.id as? String
             ?: error("更新IP访问规则时不支持的入参类型: ${any::class.qualifiedName}")

--- a/kudos-ms/kudos-ms-sys/kudos-ms-sys-core/src/io/kudos/ms/sys/core/cache/service/impl/SysCacheService.kt
+++ b/kudos-ms/kudos-ms-sys/kudos-ms-sys-core/src/io/kudos/ms/sys/core/cache/service/impl/SysCacheService.kt
@@ -212,15 +212,39 @@ open class SysCacheService(
         if (!existsKey(name, key, keyValueCache)) throw ServiceException(SysCacheErrorCodeEnum.CACHE_KEY_NOT_FOUND)
     }
 
+    /**
+     * 按缓存形态分流 existsKey 调用：keyValue 走 [KeyValueCacheKit.existsKey]，hash 走 [HashCacheKit.existsById]。
+     *
+     * @param name 缓存区名
+     * @param key 缓存 key（或 hash 的字段名）
+     * @param keyValueCache true 表示 KV 缓存，false 表示 Hash 缓存
+     * @return 是否存在
+     * @author K
+     * @since 1.0.0
+     */
     private fun existsKey(name: String, key: String, keyValueCache: Boolean): Boolean =
         if (keyValueCache) KeyValueCacheKit.existsKey(name, key) else HashCacheKit.existsById(name, key)
 
-    private inline fun <T> withCacheConfig(id: String, block: (SysCacheCacheEntry) -> T): T =
-        block(getCacheConfigById(id))
-
+    /**
+     * 从 update 入参抽 id；要求实现 [IIdEntity] 且 id 是 String。
+     *
+     * @param any 更新入参
+     * @return 缓存配置 id
+     * @throws IllegalStateException 入参类型不被支持
+     * @author K
+     * @since 1.0.0
+     */
     private fun requireCacheId(any: Any): String =
         (any as? IIdEntity<*>)?.id as? String
             ?: error("更新缓存配置时不支持的入参类型: ${any::class.qualifiedName}")
 
+    /**
+     * 判定缓存形态：`hash=false` 即视为 KeyValue 缓存。
+     *
+     * @param cache 缓存配置缓存条目
+     * @return true 表示 KV 缓存
+     * @author K
+     * @since 1.0.0
+     */
     private fun isKeyValueCache(cache: SysCacheCacheEntry): Boolean = !cache.hash
 }

--- a/kudos-ms/kudos-ms-sys/kudos-ms-sys-core/src/io/kudos/ms/sys/core/datasource/service/impl/SysDataSourceService.kt
+++ b/kudos-ms/kudos-ms-sys/kudos-ms-sys-core/src/io/kudos/ms/sys/core/datasource/service/impl/SysDataSourceService.kt
@@ -172,6 +172,14 @@ open class SysDataSourceService(
         }.onFailure { log.warn("测试数据源连通性失败 url=$url username=$username: ${it.message}") }
             .getOrDefault(false)
 
+    /**
+     * 列表增强：批量从租户缓存补 tenantName 字段，避免逐行查询。
+     * 空列表直接返回，避免向缓存层传空集合。
+     *
+     * @param records 待增强的数据源行列表（in-place 修改）
+     * @author K
+     * @since 1.0.0
+     */
     private fun enrichTenantNames(records: List<SysDataSourceRow>) {
         if (records.isEmpty()) return
         val tenants = sysTenantApi.getTenantsFromCacheByIds(records.mapNotNull { it.tenantId })
@@ -180,6 +188,17 @@ open class SysDataSourceService(
         }
     }
 
+    /**
+     * 详情增强：仅当 returnType 是 [SysDataSourceDetail] 时填充 `tenantName`；
+     * 其他返回类型保持原样，不引入无关字段。
+     *
+     * @param R 返回类型
+     * @param result 待增强对象
+     * @param returnType 期望返回类型
+     * @return 增强后的对象（类型不匹配时未被修改）
+     * @author K
+     * @since 1.0.0
+     */
     private fun <R : Any> enrichDataSourceDetail(result: R?, returnType: KClass<R>): R? {
         if (returnType == SysDataSourceDetail::class && result is SysDataSourceDetail) {
             result.tenantName = result.tenantId
@@ -189,6 +208,15 @@ open class SysDataSourceService(
         return result
     }
 
+    /**
+     * 从 update 入参抽 id；要求实现 [IIdEntity] 且 id 是 String。
+     *
+     * @param any 更新入参
+     * @return 数据源 id
+     * @throws IllegalStateException 入参类型不被支持
+     * @author K
+     * @since 1.0.0
+     */
     private fun requireDataSourceId(any: Any): String =
         (any as? IIdEntity<*>)?.id as? String
             ?: error("更新数据源时不支持的入参类型: ${any::class.qualifiedName}")

--- a/kudos-ms/kudos-ms-sys/kudos-ms-sys-core/src/io/kudos/ms/sys/core/dict/service/impl/SysDictItemService.kt
+++ b/kudos-ms/kudos-ms-sys/kudos-ms-sys-core/src/io/kudos/ms/sys/core/dict/service/impl/SysDictItemService.kt
@@ -192,6 +192,17 @@ open class SysDictItemService(
         return count
     }
 
+    /**
+     * 沿 parentId 自下而上递归收集所有祖先 id；链上某节点 parentId 为空/blank 即终止。
+     *
+     * **N+1 警告**：每层都走一次 DB 查询；当前业务字典树通常很浅 (<5 层)，可接受。
+     * 若后续遇到深树，应一次性 load 整张字典再在内存里构图。
+     *
+     * @param itemId 起点字典项 id
+     * @param results 累积容器（追加 parentId）
+     * @author K
+     * @since 1.0.0
+     */
     private fun recursionFindAllParentId(itemId: String, results: MutableList<String>) {
         val list = dao.oneSearchProperty(SysDictItem::id, itemId, SysDictItem::parentId)
         val parentId = list.firstOrNull()?.takeIf { it.isNotBlank() } ?: return
@@ -199,6 +210,14 @@ open class SysDictItemService(
         recursionFindAllParentId(parentId, results)
     }
 
+    /**
+     * 沿 parentId 自上而下递归收集所有后代 id；同样有 N+1 风险，详见 [recursionFindAllParentId]。
+     *
+     * @param itemId 起点字典项 id
+     * @param results 累积容器（追加 childId）
+     * @author K
+     * @since 1.0.0
+     */
     private fun recursionFindAllChildId(itemId: String, results: MutableList<String>) {
         val itemIds = dao.oneSearchProperty(SysDictItem::parentId, itemId, SysDictItem::id)
         itemIds.forEach { childId ->
@@ -268,6 +287,15 @@ open class SysDictItemService(
         getDirectChildrenOfItemFromCache(atomicServiceCode, dictType, itemCode, activeOnly)
             .map { SysDictItemNode(it.id, it.itemCode, it.itemName) }
 
+    /**
+     * 从 update 入参抽 id；要求实现 [IIdEntity] 且 id 是 String。
+     *
+     * @param any 更新入参
+     * @return 字典项 id
+     * @throws IllegalStateException 入参类型不被支持
+     * @author K
+     * @since 1.0.0
+     */
     private fun requireDictItemId(any: Any): String =
         (any as? IIdEntity<*>)?.id as? String
             ?: error("更新字典项时不支持的入参类型: ${any::class.qualifiedName}")

--- a/kudos-ms/kudos-ms-sys/kudos-ms-sys-core/src/io/kudos/ms/sys/core/dict/service/impl/SysDictService.kt
+++ b/kudos-ms/kudos-ms-sys/kudos-ms-sys-core/src/io/kudos/ms/sys/core/dict/service/impl/SysDictService.kt
@@ -176,11 +176,28 @@ open class SysDictService(
             dictCacheKey(dictType, atomicServiceCode) to getActiveDictItemMap(dictType, atomicServiceCode)
         }
 
+    /**
+     * 级联删除：先清字典项再删字典本身。
+     * 顺序不可换——先删字典会触发外键约束错误（字典项 FK 引用字典 id）。
+     *
+     * @param id 字典 id
+     * @return 字典本身删除是否成功（字典项删除不计入返回值，但失败会因为约束反向阻断）
+     * @author K
+     * @since 1.0.0
+     */
     private fun deleteDictWithItems(id: String): Boolean {
         dao.deleteDictItemsByDictId(id)
         return deleteDict(id)
     }
 
+    /**
+     * 单字典删除：DAO 删行 → 成功则发 [SysDictDeleted] 事件供下游清缓存；失败仅 ERROR 日志。
+     *
+     * @param id 字典 id
+     * @return 是否真的删到行
+     * @author K
+     * @since 1.0.0
+     */
     private fun deleteDict(id: String): Boolean {
         val success = dao.deleteById(id)
         if (success) {
@@ -191,15 +208,52 @@ open class SysDictService(
         return success
     }
 
+    /**
+     * 取生效字典项缓存（active=true 已由 `SysDictItemService` 缓存侧筛过）。
+     *
+     * @param dictType 字典类型
+     * @param atomicServiceCode 原子服务编码（多租户/多服务隔离 key）
+     * @return 字典项缓存条目列表
+     * @author K
+     * @since 1.0.0
+     */
     private fun getActiveDictItems(dictType: String, atomicServiceCode: String): List<SysDictItemCacheEntry> =
         sysDictItemService.getDictItemsFromCache(dictType, atomicServiceCode)
 
+    /**
+     * 生效字典项的 itemCode → itemName 映射；用 [LinkedHashMap] 保留插入顺序以维持业务排序。
+     *
+     * @param dictType 字典类型
+     * @param atomicServiceCode 原子服务编码
+     * @return itemCode → itemName 的有序映射
+     * @author K
+     * @since 1.0.0
+     */
     private fun getActiveDictItemMap(dictType: String, atomicServiceCode: String): LinkedHashMap<String, String> =
         getActiveDictItems(dictType, atomicServiceCode).associateTo(LinkedHashMap()) { it.itemCode to it.itemName }
 
+    /**
+     * 构造字典批量缓存命中的 key 对：`(atomicServiceCode, dictType)`。
+     * **注意顺序**——批量入参是 `(dictType, atomicServiceCode)`，这里特意翻转，
+     * 与下游 `batchGetActiveDictItemMapFromCache` 返回值的 key 顺序保持一致，避免调用方对错位置。
+     *
+     * @param dictType 字典类型
+     * @param atomicServiceCode 原子服务编码
+     * @return `(atomicServiceCode, dictType)` 顺序的 Pair
+     * @author K
+     * @since 1.0.0
+     */
     private fun dictCacheKey(dictType: String, atomicServiceCode: String): Pair<String, String> =
         Pair(atomicServiceCode, dictType)
 
+    /**
+     * 把 PO [SysDict] 拷成扁平的 VO [SysDictRow]，用于 list 接口（避免暴露 ORM Entity 字段）。
+     *
+     * @param dict 字典 PO
+     * @return 字典 VO
+     * @author K
+     * @since 1.0.0
+     */
     private fun toSysDictRow(dict: SysDict): SysDictRow = SysDictRow(
         id = dict.id,
         dictType = dict.dictType,
@@ -210,6 +264,15 @@ open class SysDictService(
         builtIn = dict.builtIn,
     )
 
+    /**
+     * 从 update 入参抽 id；要求入参实现 [IIdEntity] 且 id 是 String。
+     *
+     * @param any 更新入参
+     * @return 字典 id
+     * @throws IllegalStateException 入参类型不被支持
+     * @author K
+     * @since 1.0.0
+     */
     private fun requireDictId(any: Any): String =
         (any as? IIdEntity<*>)?.id as? String
             ?: error("更新字典时不支持的入参类型: ${any::class.qualifiedName}")

--- a/kudos-ms/kudos-ms-sys/kudos-ms-sys-core/src/io/kudos/ms/sys/core/domain/service/impl/SysDomainService.kt
+++ b/kudos-ms/kudos-ms-sys/kudos-ms-sys-core/src/io/kudos/ms/sys/core/domain/service/impl/SysDomainService.kt
@@ -155,6 +155,15 @@ open class SysDomainService(
         return count
     }
 
+    /**
+     * 从 update 入参抽 id；要求实现 [IIdEntity] 且 id 是 String。
+     *
+     * @param any 更新入参
+     * @return 域名 id
+     * @throws IllegalStateException 入参类型不被支持
+     * @author K
+     * @since 1.0.0
+     */
     private fun requireDomainId(any: Any): String =
         (any as? IIdEntity<*>)?.id as? String
             ?: error("更新域名时不支持的入参类型: ${any::class.qualifiedName}")

--- a/kudos-ms/kudos-ms-sys/kudos-ms-sys-core/src/io/kudos/ms/sys/core/i18n/service/impl/SysI18NService.kt
+++ b/kudos-ms/kudos-ms-sys/kudos-ms-sys-core/src/io/kudos/ms/sys/core/i18n/service/impl/SysI18NService.kt
@@ -150,6 +150,15 @@ open class SysI18NService(
         return count
     }
 
+    /**
+     * 标准化命名空间和 key：namespace 为空时退化为 `i18nTypeDictCode`（即把"类型"当默认命名空间）。
+     *
+     * @param payload 表单入参
+     * @return `(namespace, key)` 对
+     * @throws IllegalArgumentException key 或 i18nTypeDictCode 为空时
+     * @author K
+     * @since 1.0.0
+     */
     private fun resolveNamespaceAndKey(payload: SysI18nFormUpdate): Pair<String, String> {
         val key = requireNotNull(payload.key) { "key不能为空。" }
         val i18nTypeDictCode = requireNotNull(payload.i18nTypeDictCode) { "i18nTypeDictCode不能为空。" }
@@ -157,6 +166,16 @@ open class SysI18NService(
         return namespace to key
     }
 
+    /**
+     * upsert 入口：根据 `form.id` 是否为空切换"insert + 发 Inserted 事件" 或 "update + 发 Updated 事件"。
+     *
+     * 注意：update 路径成功时才发事件，否则不发——避免下游基于事件做缓存失效却没真改库。
+     *
+     * @param form 入参（含可选 id）
+     * @return 是否成功；insert 路径只要不抛异常即返回 true
+     * @author K
+     * @since 1.0.0
+     */
     private fun saveOrUpdateI18n(form: SysI18nFormUpdate): Boolean =
         if (form.id.isNullOrBlank()) {
             val id = dao.insert(toI18n(form, creating = true))
@@ -167,6 +186,18 @@ open class SysI18NService(
             dao.update(i18n).also { if (it) eventPublisher.publishEvent(SysI18nUpdated(id = i18n.id)) }
         }
 
+    /**
+     * 把 [SysI18nFormUpdate] 表单映射成 PO [SysI18n]：
+     * - creating=false 时强制要求 id 非空（更新场景必须知道目标行）
+     * - 其余字段统一校验非空，error message 区分"新增/更新"语境便于运维定位
+     *
+     * @param form 表单入参
+     * @param creating true=新增场景，false=更新场景
+     * @return PO 对象
+     * @throws IllegalArgumentException 必填字段为空时
+     * @author K
+     * @since 1.0.0
+     */
     private fun toI18n(form: SysI18nFormUpdate, creating: Boolean): SysI18n {
         val operation = if (creating) "新增" else "更新"
         val (namespace, key) = resolveNamespaceAndKey(form)
@@ -188,6 +219,15 @@ open class SysI18NService(
         }
     }
 
+    /**
+     * 从 update 入参抽 id；要求实现 [IIdEntity] 且 id 是 String。
+     *
+     * @param any 更新入参
+     * @return 国际化记录 id
+     * @throws IllegalStateException 入参类型不被支持
+     * @author K
+     * @since 1.0.0
+     */
     private fun requireI18nId(any: Any): String =
         (any as? IIdEntity<*>)?.id as? String
             ?: error("更新国际化内容时不支持的入参类型: ${any::class.qualifiedName}")

--- a/kudos-ms/kudos-ms-sys/kudos-ms-sys-core/src/io/kudos/ms/sys/core/locale/service/impl/SysLocaleService.kt
+++ b/kudos-ms/kudos-ms-sys/kudos-ms-sys-core/src/io/kudos/ms/sys/core/locale/service/impl/SysLocaleService.kt
@@ -112,6 +112,15 @@ open class SysLocaleService(
         return count
     }
 
+    /**
+     * 从 update 入参抽 id；要求实现 [IIdEntity] 且 id 是 String。
+     *
+     * @param any 更新入参
+     * @return 语言 id
+     * @throws IllegalStateException 入参类型不被支持
+     * @author K
+     * @since 1.0.0
+     */
     private fun requireLocaleId(any: Any): String =
         (any as? IIdEntity<*>)?.id as? String
             ?: error("更新语言时不支持的入参类型: ${any::class.qualifiedName}")

--- a/kudos-ms/kudos-ms-sys/kudos-ms-sys-core/src/io/kudos/ms/sys/core/microservice/service/impl/SysMicroServiceService.kt
+++ b/kudos-ms/kudos-ms-sys/kudos-ms-sys-core/src/io/kudos/ms/sys/core/microservice/service/impl/SysMicroServiceService.kt
@@ -149,9 +149,26 @@ open class SysMicroServiceService(
         return count
     }
 
+    /**
+     * 把缓存条目映射为树节点：code 作为节点 id，parentCode 作为 parent 链。
+     *
+     * @param microService 微服务缓存条目
+     * @return 树节点
+     * @author K
+     * @since 1.0.0
+     */
     private fun toTreeNode(microService: SysMicroServiceCacheEntry): IdAndNameTreeNode<String> =
         IdAndNameTreeNode(microService.code, microService.name, microService.parentCode)
 
+    /**
+     * 从 update 入参抽 code（这里 id 即 code）；要求实现 [IIdEntity] 且 id 是 String。
+     *
+     * @param any 更新入参
+     * @return 微服务 code
+     * @throws IllegalStateException 入参类型不被支持
+     * @author K
+     * @since 1.0.0
+     */
     private fun requireMicroServiceCode(any: Any): String =
         (any as? IIdEntity<*>)?.id as? String
             ?: error("更新微服务时不支持的入参类型: ${any::class.qualifiedName}")

--- a/kudos-ms/kudos-ms-sys/kudos-ms-sys-core/src/io/kudos/ms/sys/core/outline/service/impl/SysOutLineService.kt
+++ b/kudos-ms/kudos-ms-sys/kudos-ms-sys-core/src/io/kudos/ms/sys/core/outline/service/impl/SysOutLineService.kt
@@ -108,6 +108,15 @@ open class SysOutLineService(
         return count
     }
 
+    /**
+     * 从 update 入参抽 id；要求实现 [IIdEntity] 且 id 是 String。
+     *
+     * @param any 更新入参
+     * @return 出网白名单 id
+     * @throws IllegalStateException 入参类型不被支持
+     * @author K
+     * @since 1.0.0
+     */
     private fun requireOutLineId(any: Any): String =
         (any as? IIdEntity<*>)?.id as? String
             ?: error("更新出网白名单时不支持的入参类型: ${any::class.qualifiedName}")

--- a/kudos-ms/kudos-ms-sys/kudos-ms-sys-core/src/io/kudos/ms/sys/core/param/service/impl/SysParamService.kt
+++ b/kudos-ms/kudos-ms-sys/kudos-ms-sys-core/src/io/kudos/ms/sys/core/param/service/impl/SysParamService.kt
@@ -134,6 +134,15 @@ open class SysParamService(
         return count
     }
 
+    /**
+     * 从 update 入参抽 id；要求实现 [IIdEntity] 且 id 是 String。
+     *
+     * @param any 更新入参
+     * @return 参数 id
+     * @throws IllegalStateException 入参类型不被支持
+     * @author K
+     * @since 1.0.0
+     */
     private fun requireParamId(any: Any): String =
         (any as? IIdEntity<*>)?.id as? String
             ?: error("更新参数时不支持的入参类型: ${any::class.qualifiedName}")

--- a/kudos-ms/kudos-ms-sys/kudos-ms-sys-core/src/io/kudos/ms/sys/core/resource/service/impl/SysResourceService.kt
+++ b/kudos-ms/kudos-ms-sys/kudos-ms-sys-core/src/io/kudos/ms/sys/core/resource/service/impl/SysResourceService.kt
@@ -331,12 +331,34 @@ open class SysResourceService(
         return detail
     }
 
+    /**
+     * 走资源 hash 缓存按子系统编码 + 资源类型取列表。
+     * 给多个 `*FromCache` overrides 复用，避免在每处重复"枚举 → code"的转换。
+     *
+     * @param subSystemCode 子系统编码
+     * @param resourceType 资源类型枚举
+     * @return 资源缓存条目列表
+     * @author K
+     * @since 1.0.0
+     */
     private fun getCachedResourcesByType(
         subSystemCode: String,
         resourceType: ResourceTypeEnum,
     ): List<SysResourceCacheEntry> =
         sysResourceHashCache.getResourcesBySubSystemCodeAndType(subSystemCode, resourceType.code)
 
+    /**
+     * 把扁平的 [SysResourceRow] 列表按 parentId 装配成树。
+     *
+     * 算法：先把每行映射为 [SysResourceTreeRow] 并按 id 做 map → 再遍历挂到父节点的 children；
+     * 父节点不在列表里则视为根。最后按 orderNum 递归排序。
+     *
+     * @param records 待装配的扁平资源列表
+     * @param parentId 指定根：非空时只返回该节点的子树
+     * @return 根节点列表（或指定 parentId 的子节点）
+     * @author K
+     * @since 1.0.0
+     */
     private fun buildResourceTree(
         records: List<SysResourceRow>,
         parentId: String?,
@@ -351,6 +373,14 @@ open class SysResourceService(
         return parentId?.let { nodeMap[it]?.children.orEmpty() } ?: rootNodes
     }
 
+    /**
+     * 把 [SysResourceRow] 浅拷贝成 [SysResourceTreeRow]，初始 children 为空容器以备后续挂载。
+     *
+     * @param record 单条资源记录
+     * @return 树节点
+     * @author K
+     * @since 1.0.0
+     */
     private fun toTreeRow(record: SysResourceRow): SysResourceTreeRow =
         SysResourceTreeRow(
             id = record.id,
@@ -367,6 +397,13 @@ open class SysResourceService(
             children = mutableListOf(),
         )
 
+    /**
+     * 递归按 orderNum 升序排序节点列表及其子树；null orderNum 排到最末（按 Int.MAX_VALUE 处理）。
+     *
+     * @param nodes 待排序节点列表（in-place 排序）
+     * @author K
+     * @since 1.0.0
+     */
     private fun sortResourceTree(nodes: MutableList<SysResourceTreeRow>) {
         nodes.sortBy { it.orderNum ?: Int.MAX_VALUE }
         nodes.forEach { node ->
@@ -374,14 +411,43 @@ open class SysResourceService(
         }
     }
 
+    /**
+     * 资源更新后的同步动作：当前只发 [SysResourceUpdated] 事件，由各级缓存订阅者自行刷新。
+     *
+     * 入参 `any` / `oldResource` 暂未使用——保留参数是为给后续做"差量缓存清理"留扩展点
+     * （例如旧 parentId 变化时需要同时清新旧父节点的子树缓存）。
+     *
+     * @param any 更新入参（含新字段值）
+     * @param id 资源 id
+     * @param oldResource 更新前的资源快照，可为 null
+     * @author K
+     * @since 1.0.0
+     */
     private fun syncResourceUpdate(any: Any, id: String, oldResource: SysResource?) {
         eventPublisher.publishEvent(SysResourceUpdated(id = id))
     }
 
+    /**
+     * 资源删除后的同步动作：发 [SysResourceDeleted] 事件由订阅者清理缓存/外链。
+     *
+     * @param resource 已被删除的资源对象（带 id）
+     * @author K
+     * @since 1.0.0
+     */
     private fun syncResourceDelete(resource: SysResource) {
         eventPublisher.publishEvent(SysResourceDeleted(id = resource.id))
     }
 
+    /**
+     * 自底向上沿 parentId 链收集所有祖先 id；链上某节点不存在或 parentId 为空即终止。
+     *
+     * 注意：调用方 [fetchAllParentIds] 会再 `reverse()`，所以结果是"从近到远"。
+     *
+     * @param itemId 起点节点 id
+     * @param results 累积容器（追加）
+     * @author K
+     * @since 1.0.0
+     */
     private fun collectParentIds(itemId: String, results: MutableList<String>) {
         var currentId: String? = itemId
         while (currentId != null) {
@@ -391,6 +457,16 @@ open class SysResourceService(
         }
     }
 
+    /**
+     * 从 update 入参中抽 id：限定入参实现 [IIdEntity] 且 id 是 String。
+     * 不满足契约直接 [error]——属于编程错误，不该静默失败。
+     *
+     * @param any 更新入参
+     * @return 资源 id
+     * @throws IllegalStateException 入参类型不被支持
+     * @author K
+     * @since 1.0.0
+     */
     private fun requireResourceId(any: Any): String =
         (any as? IIdEntity<*>)?.id as? String
             ?: error("更新资源时不支持的入参类型: ${any::class.qualifiedName}")

--- a/kudos-ms/kudos-ms-sys/kudos-ms-sys-core/src/io/kudos/ms/sys/core/system/service/impl/SysSystemService.kt
+++ b/kudos-ms/kudos-ms-sys/kudos-ms-sys-core/src/io/kudos/ms/sys/core/system/service/impl/SysSystemService.kt
@@ -148,6 +148,15 @@ open class SysSystemService(
         return count
     }
 
+    /**
+     * 从 update 入参抽 code（这里 id 即 code）；要求实现 [IIdEntity] 且 id 是 String。
+     *
+     * @param any 更新入参
+     * @return 系统 code
+     * @throws IllegalStateException 入参类型不被支持
+     * @author K
+     * @since 1.0.0
+     */
     private fun requireSystemCode(any: Any): String =
         (any as? IIdEntity<*>)?.id as? String
             ?: error("更新系统时不支持的入参类型: ${any::class.qualifiedName}")

--- a/kudos-ms/kudos-ms-sys/kudos-ms-sys-core/src/io/kudos/ms/sys/core/tenant/service/impl/SysTenantService.kt
+++ b/kudos-ms/kudos-ms-sys/kudos-ms-sys-core/src/io/kudos/ms/sys/core/tenant/service/impl/SysTenantService.kt
@@ -101,6 +101,17 @@ open class SysTenantService(
         return id
     }
 
+    /**
+     * 批量插入"租户 ↔ 子系统"关联表行。
+     *
+     * 把 `subSystemCodes` 每个 code 映射成 [SysTenantSystem] 实体后走 `batchInsert`，
+     * 一次写入避免 N+1。
+     *
+     * @param tenantId 租户 id
+     * @param subSystemCodes 子系统编码集合
+     * @author K
+     * @since 1.0.0
+     */
     private fun insertSysTenantSystems(tenantId: String, subSystemCodes: Set<String>) {
         val tenantSystems = subSystemCodes.mapTo(mutableSetOf()) { subSystemCode ->
             SysTenantSystem().apply {
@@ -178,6 +189,14 @@ open class SysTenantService(
     override fun getTenantByName(name: String): SysTenantRow? =
         dao.search(Criteria(SysTenant::name eq name)).firstOrNull()?.let(::toSysTenantRow)
 
+    /**
+     * 租户更新时同步"租户↔子系统"绑定：仅 [SysTenantFormUpdate] 入参才会触发，
+     * 与缓存差异比对后才走 replace——避免无差异时空转 DB 和触发缓存失效抖动。
+     *
+     * @param any 更新入参，非 [SysTenantFormUpdate] 直接 no-op
+     * @author K
+     * @since 1.0.0
+     */
     private fun syncTenantSystemsOnUpdate(any: Any) {
         if (any !is SysTenantFormUpdate) return
 
@@ -188,23 +207,59 @@ open class SysTenantService(
         }
     }
 
+    /**
+     * "全量替换"语义：先清旧关联再插入新集合。
+     * 简单粗暴但避免了"增量 diff"的复杂度——绑定数量很小，性能可接受。
+     *
+     * @param tenantId 租户 id
+     * @param subSystemCodes 新的子系统集合
+     * @author K
+     * @since 1.0.0
+     */
     private fun replaceTenantSystems(tenantId: String, subSystemCodes: Set<String>) {
         deleteTenantSystems(tenantId)
         insertSysTenantSystems(tenantId, subSystemCodes)
     }
 
+    /**
+     * 清除某租户名下所有子系统绑定。
+     * 缓存失效由 `sysTenantSystemService.deleteByTenantId` 内部发的
+     * `SysTenantSystemTenantsChanged` 事件驱动 `SysTenantSystemHashCache` 自动完成。
+     *
+     * @param tenantId 租户 id
+     * @author K
+     * @since 1.0.0
+     */
     private fun deleteTenantSystems(tenantId: String) {
         // sysTenantSystemService.deleteByTenantId 已发布 SysTenantSystemTenantsChanged，
         // 由 SysTenantSystemHashCache.on(...) 订阅完成失效。
         sysTenantSystemService.deleteByTenantId(tenantId)
     }
 
+    /**
+     * 租户新建时按入参类型选择性插入子系统绑定：仅 [SysTenantFormCreate] 入参触发。
+     *
+     * @param any 新建入参
+     * @param tenantId 已生成的租户 id
+     * @author K
+     * @since 1.0.0
+     */
     private fun insertTenantSystemsOnCreate(any: Any, tenantId: String) {
         if (any is SysTenantFormCreate) {
             insertSysTenantSystems(tenantId, any.subSystemCodes)
         }
     }
 
+    /**
+     * 详情对象的增强：仅 [SysTenantDetail] 类型才填充 `subSystemCodes` 字段，其他返回类型原样返回。
+     *
+     * @param R 返回类型
+     * @param result 待增强对象
+     * @param tenantId 租户 id
+     * @return 增强后的对象（可能未被修改）
+     * @author K
+     * @since 1.0.0
+     */
     private fun <R : Any> enrichTenantDetail(result: R?, tenantId: String): R? {
         if (result is SysTenantDetail) {
             result.subSystemCodes = getSubSystemCodesString(tenantId)
@@ -212,10 +267,25 @@ open class SysTenantService(
         return result
     }
 
+    /**
+     * 列表行的增强：直接给 [SysTenantRow] 设 `subSystemCodes` 字符串字段（逗号分隔）。
+     *
+     * @param row 待增强的列表行
+     * @author K
+     * @since 1.0.0
+     */
     private fun enrichTenantRow(row: SysTenantRow) {
         row.subSystemCodes = getSubSystemCodesString(row.id)
     }
 
+    /**
+     * 把 PO [SysTenant] 拷成扁平 VO [SysTenantRow]，用于 list 接口。
+     *
+     * @param tenant 租户 PO
+     * @return 租户 VO（`subSystemCodes` 字段未填，由 [enrichTenantRow] 后续补齐）
+     * @author K
+     * @since 1.0.0
+     */
     private fun toSysTenantRow(tenant: SysTenant): SysTenantRow = SysTenantRow(
         id = tenant.id,
         name = tenant.name,
@@ -231,9 +301,26 @@ open class SysTenantService(
     override fun getSubSystemCodesFromCache(tenantId: String): Set<String> =
         sysTenantSystemHashCache.getSubSystemCodesByTenantId(tenantId)
 
+    /**
+     * 把租户绑定的子系统集合拍扁成逗号分隔字符串，用于在列表/详情里直接展示。
+     *
+     * @param tenantId 租户 id
+     * @return 形如 `"sys, msg, user"` 的字符串；无绑定时为空串
+     * @author K
+     * @since 1.0.0
+     */
     private fun getSubSystemCodesString(tenantId: String): String =
         sysTenantSystemHashCache.getSubSystemCodesByTenantId(tenantId).joinToString(", ")
 
+    /**
+     * 从 update 入参抽 id；要求实现 [IIdEntity] 且 id 是 String。不满足直接 [error]。
+     *
+     * @param any 更新入参
+     * @return 租户 id
+     * @throws IllegalStateException 入参类型不被支持
+     * @author K
+     * @since 1.0.0
+     */
     private fun requireTenantId(any: Any): String =
         (any as? IIdEntity<*>)?.id as? String
             ?: error("更新租户时不支持的入参类型: ${any::class.qualifiedName}")

--- a/kudos-ms/kudos-ms-user/kudos-ms-user-core/src/io/kudos/ms/user/core/account/service/impl/UserAccountService.kt
+++ b/kudos-ms/kudos-ms-user/kudos-ms-user-core/src/io/kudos/ms/user/core/account/service/impl/UserAccountService.kt
@@ -260,7 +260,18 @@ open class UserAccountService(
         return GoogleAuthenticator().checkCode(key, code, System.currentTimeMillis())
     }
 
-    // RFC 6238 / Google Authenticator 标签格式：`issuer:account`（整体再 URL 编码）
+    /**
+     * 按 RFC 6238 / Google Authenticator 规范拼出 `otpauth://` URI 的 label 段。
+     *
+     * 格式约定：`issuer:accountName` 整体做 URL 编码——冒号在编码后会变成 `%3A`，正符合 GA App 解析期望。
+     * 如果 issuer 或 accountName 含空格 / 特殊字符（中文用户名常见），不编码会破坏整个 URI。
+     *
+     * @param issuer 应用方标识（通常是产品名）
+     * @param accountName 账号名（用户登录名/邮箱）
+     * @return 编码后的 label 段
+     * @author K
+     * @since 1.0.0
+     */
     private fun encodeOtpAuthLabel(issuer: String, accountName: String): String =
         java.net.URLEncoder.encode("$issuer:$accountName", Charsets.UTF_8)
 


### PR DESCRIPTION
…ices

补齐 kudos-ms-* 各 *Service.kt 中私有 helper 方法的 KDoc 注释：

- AuthModuleEnum: 标注空枚举的 SPI 占位语义
- SysResourceService: 8 个树构建 / 同步 / requireResourceId helper
- SysDictService: 7 个级联删除 / 字典项映射 / 缓存 key / requireDictId helper
- SysDictItemService: 2 个递归收集祖先/后代 id (N+1 警告) + requireDictItemId
- SysTenantService: 10 个 tenant↔subsystem 关联同步 helper
- SysI18NService: 4 个 upsert / 表单→PO / requireI18nId helper
- SysDataSourceService: 3 个批量补租户名 / 详情增强 / requireDataSourceId
- SysCacheService: 3 个 KV/Hash 分流 existsKey / requireCacheId / isKeyValueCache
- 8 个独立的 requireXxxId boilerplate（domain/system/param/locale/outline/microservice/accessRuleIp/etc）
- UserAccountService: encodeOtpAuthLabel — 解释 RFC 6238 label 编码语义

公共原则仍是：
- 仅补私有 helper / 实现侧的非平凡逻辑
- override 公共方法继续走 IXxxService 接口注释（避免与契约 KDoc 冗余）
- 在 KDoc 里写"为什么"和"陷阱"——例如 N+1 警告、删除顺序的 FK 约束、批量替换的 trade-off