### PR TITLE
Restructure flyway multi-ds: ds→modules, auto-scan, execution-order

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -121,6 +121,10 @@ spring-boot-starter-jdbc = { module = "org.springframework.boot:spring-boot-star
 spring-boot-starter-jetty = { module = "org.springframework.boot:spring-boot-starter-jetty"}
 #spring-boot-starter-undertow = { module = "org.springframework.boot:spring-boot-starter-undertow"}
 spring-boot-starter-flyway = { module = "org.springframework.boot:spring-boot-starter-flyway"}
+# Flyway 10+ split database adapters into separate artifacts; spring-boot-starter-flyway no longer
+# pulls in the PG adapter, and without it Flyway throws "Unsupported Database" on PostgreSQL (incl. 18).
+# Version is aligned by the spring-boot BOM.
+flyway-database-postgresql = { module = "org.flywaydb:flyway-database-postgresql"}
 spring-cloud-loadbalancer = { module = "org.springframework.cloud:spring-cloud-loadbalancer"}
 spring-cloud-starter-openfeign = { module = "org.springframework.cloud:spring-cloud-starter-openfeign"}
 spring-cloud-stream = { module = "org.springframework.cloud:spring-cloud-stream"}

--- a/kudos-ability/kudos-ability-data/kudos-ability-data-rdb/kudos-ability-data-rdb-flyway/README.md
+++ b/kudos-ability/kudos-ability-data/kudos-ability-data-rdb/kudos-ability-data-rdb-flyway/README.md
@@ -1,41 +1,51 @@
 # kudos-ability-data-rdb-flyway
 
-Spring Boot 启动期的多数据源 Flyway 迁移器。把 SQL 脚本按"模块 × 数据库类型"分目录组织，
-启动时按声明顺序逐模块跑 Flyway，任何一个模块失败都打断启动（不会在错位的 schema 上跑业务）。
+Multi-data-source Flyway migrator that runs at Spring Boot startup. SQL scripts are organized by
+"module × database type"; at startup each module is migrated in the declared order, and any single
+module's failure aborts startup (so the app never runs against a half-migrated schema).
 
-## 何时用它
+## When to use it
 
-- 单进程同时管理多个 RDB 数据源（比如 `master` + `audit_log` + `tenant_*`），每个数据源
-  跑自己一套迁移
-- 同一份 SQL 脚本要兼容多种数据库类型（h2 跑测试 / postgresql 跑生产），脚本按 dbType 分目录
+- A single process manages multiple RDB data sources (e.g. `master` + `audit_log` + `tenant_*`),
+  each with its own set of migrations.
+- The same SQL needs to run against multiple database types (h2 for tests / postgresql for prod);
+  scripts are split per dbType subdirectory.
 
-如果只有一个数据源，Spring Boot 自带的 `spring-boot-starter-flyway` 已经够用，本模块就是 overkill。
+If you only have one data source, Spring Boot's stock `spring-boot-starter-flyway` is enough and
+this module is overkill.
 
-## 约定
+## Convention
 
 ```
 classpath:sql/
-    └─ <moduleName>/                ← 一个 kudos 业务模块一个目录
-        └─ <dbType>/                ← postgresql / h2 / mysql ...（RdbTypeEnum#name.lowercase()）
-            ├─ V1.0.0__init.sql     ← Flyway 标准命名
+    └─ <moduleName>/                ← one directory per kudos business module
+        └─ <dbType>/                ← postgresql / h2 / mysql ... (RdbTypeEnum#name.lowercase())
+            ├─ V1.0.0__init.sql     ← Flyway standard naming
             └─ V1.0.1__add_x.sql
 ```
 
-每个业务模块用独立的 Flyway 元数据表 `flyway_history_<moduleName>`，互不污染。
+Each module uses its own Flyway metadata table `flyway_history_<moduleName>`, so they never
+contaminate one another.
 
-## 配置
+## Configuration
 
 ```yaml
 kudos:
   ability:
     flyway:
-      enabled: true                # 可设 false 整体禁用启动迁移（只读副本场景）
-      datasource-config:           # 模块 → 动态数据源 key 映射，按声明顺序迁移
-        sys: master
-        audit_log: audit
-        tenant: master
+      enabled: true                # set to false to disable startup migration entirely
+                                   # (e.g. read-only replicas)
+      datasource-config:           # ds → module list, migrated in declaration order
+        master: sys,tenant         # CSV form
+        audit:                     # list form
+          - audit_log
+      execution-order:             # optional: explicitly override ds execution order;
+        - master                   # unlisted entries keep their original relative order
+        - audit                    # and follow at the end
+      auto-config:
+        enabled: false             # see "Two modes" below
 
-# Flyway 自身参数走 Spring Boot 标准前缀
+# Flyway's own parameters live under the standard Spring Boot prefix
 spring:
   flyway:
     baseline-on-migrate: true
@@ -47,51 +57,78 @@ spring:
       app_schema: public
 ```
 
-`kudos.ability.flyway.*` 和 `spring.flyway.*` 不重叠：前者只决定"哪个模块用哪个数据源"，
-后者控制 Flyway 自身行为（baseline / encoding / outOfOrder ...）。
+`kudos.ability.flyway.*` and `spring.flyway.*` do not overlap: the former only decides "which data
+source runs which modules and in what order"; the latter controls Flyway's own behavior
+(baseline / encoding / outOfOrder / placeholders ...).
 
-## 模块入口
+## Two modes
 
-| 类 | 角色 |
+| Mode | `auto-config.enabled` | Behavior |
+|---|---|---|
+| Manual (default) | `false` | Migrate only the modules listed in `datasource-config`; modules on disk but not declared are silently skipped; modules declared but missing on disk are warned. |
+| Auto-scan | `true` | Scan `classpath:sql/*`; **every discovered module must have a ds mapping under `datasource-config`**, otherwise startup aborts. (Auto only relaxes discovery, not the mapping decision.) |
+
+## Module entry points
+
+| Class | Role |
 |---|---|
-| `FlywayAutoConfiguration` | 装配入口；`@ConditionalOnProperty(kudos.ability.flyway.enabled, default=true)` 决定是否启用 |
-| `FlywayMultiDataSourceMigrator` | 启动期被调用的迁移器，扫 classpath + 走 properties + 逐模块迁移 |
-| `FlywayMultiDataSourceProperties` | 模块名 → 数据源 key 的 yml 绑定 |
-| `FlywayKit` | 单模块迁移的纯函数实现，**脱离 Spring 也能用**（代码生成器 / CLI 工具直接调） |
+| `FlywayAutoConfiguration` | Wiring entry; `@ConditionalOnProperty(kudos.ability.flyway.enabled, default=true)` controls whether it activates. |
+| `FlywayMultiDataSourceMigrator` | Startup-time migrator; scans classpath, reconciles with properties, runs migrations by ds in order. `migrateByModule(name)` is the single-module entry point. |
+| `FlywayMultiDataSourceProperties` | yml binding for `ds → modules`; values may be CSV strings or YAML lists. |
+| `FlywayPreConfiguration` + `FlywayModuleStrategy` | Suppress Spring Boot's default Flyway behavior (otherwise it would try to migrate `classpath:db/migration` against the primary data source). |
+| `FlywayKit` | Pure-function single-module migration; **also usable outside Spring** (code generators / CLI tools can call it directly). |
 
-## 失败语义
+## Failure semantics
 
-- Flyway `migrate()` 报 `success=false` —— 抛 `IllegalStateException`，打断启动
-- 配置里模块对应的数据源 key 不存在 —— 抛 `IllegalStateException`
-- 同一个模块名在多个 classpath URL 同时出现 —— 抛 `IllegalStateException`
-- 配置里声明的模块名磁盘上找不到 —— 仅打 warn 日志，继续
-- `spring.flyway.placeholders`、`placeholder-prefix`、`placeholder-suffix`、`placeholder-separator`
-  会透传给每个模块的 Flyway 实例
+- Flyway `migrate()` reports `success=false` → throws `IllegalStateException` and aborts startup.
+- The data source key configured for a module does not exist → throws `IllegalStateException`; the
+  error message lists which yml file(s) the `datasource-config` came from.
+- The same module name appears under multiple classpath URLs → throws `IllegalStateException`.
+- A module declared in config has no scripts on disk → logs a warning and continues.
+- With `auto-config.enabled=true`, a module exists on disk but has no mapping in `datasource-config`
+  → throws `IllegalStateException`.
+- A `execution-order` mis-indented under `datasource-config` is ignored by the reserved-key
+  defense, never interpreted as a ds name.
+- `spring.flyway.placeholders` / `placeholder-prefix` / `placeholder-suffix` / `placeholder-separator`
+  are all propagated to every per-module Flyway instance.
 
-设计原则：**宁可启动不来，也不让应用跑在不一致的 schema 上**。
+Design principle: **better to fail startup than to run the app against an inconsistent schema**.
 
-## 依赖
+## Error tracing
+
+When migration fails, the error message lists which configuration sources contributed
+`kudos.ability.flyway.datasource-config.*` entries (powered by
+`YamlPropertySourceFactory.getSourceMap()`). In multi-jar / multi-yml deployments this lets you
+quickly pinpoint which dependency wrote the offending config.
+
+## Dependencies
 
 ```kotlin
 api(project(":kudos-ability:kudos-ability-data:kudos-ability-data-rdb:kudos-ability-data-rdb-jdbc"))
 api(libs.spring.boot.starter.flyway)
+api(libs.flyway.database.postgresql)        // Flyway 10+ split the PG adapter into its own artifact;
+                                            // without it, startup against PG (incl. 18) throws "Unsupported Database".
 api(libs.baomidou.dynamic.datasource.starter)
 ```
 
-通过 `DsContextProcessor` 拿动态数据源 —— 因此**目前依赖 baomidou dynamic-datasource starter**。
-如果未来要解耦，需要把"按 key 取 DataSource"抽象成一个 SPI。
+Data sources are resolved via `DsContextProcessor`, so this module **currently depends on the
+baomidou dynamic-datasource starter**. Decoupling would require abstracting "look up DataSource by
+key" into a SPI.
 
-## 已知限制 / 后续工作
+## Known limitations / future work
 
-- ❗ 没有 Flyway callback / hook 暴露（pre-migrate / post-migrate）
-- ✅ Flyway placeholders 已透传：支持 `spring.flyway.placeholders` 以及 placeholder 前缀 / 后缀 /
-  分隔符配置
-- ❗ 紧耦合 `DsContextProcessor` —— 不用 baomidou dynamic-datasource 就用不了本模块
-- ❗ 没有 dry-run / repair / clean 入口；运维脚本要绕过本模块直接用 Flyway CLI
-- ❗ 测试覆盖到 happy path、缺失数据源、placeholders 替换；jar 协议路径扫描、重复模块检测、
-  Flyway 失败等分支未直接单测
+- ❗ No Flyway callback / hook surface exposed (pre-migrate / post-migrate).
+- ✅ Flyway placeholders are propagated: `placeholders / prefix / suffix / separator` all reach
+  every per-module Flyway instance.
+- ❗ Tightly coupled to `DsContextProcessor` — this module is unusable without baomidou
+  dynamic-datasource.
+- ❗ No dry-run / repair / clean entry points; ops scripts must bypass this module and use the
+  Flyway CLI directly.
+- ❗ Test coverage: happy path, missing data source, placeholder substitution, CSV/List parsing,
+  execution-order. The jar-protocol path scan, duplicate-module detection, and auto-mode
+  missing-mapping branches are not directly unit-tested yet.
 
-## 用法示例：脱离 Spring 跑迁移（代码生成器场景）
+## Example: running migrations outside Spring (code generator scenario)
 
 ```kotlin
 val ds = HikariDataSource(/* ... */)

--- a/kudos-ability/kudos-ability-data/kudos-ability-data-rdb/kudos-ability-data-rdb-flyway/build.gradle.kts
+++ b/kudos-ability/kudos-ability-data/kudos-ability-data-rdb/kudos-ability-data-rdb-flyway/build.gradle.kts
@@ -1,6 +1,7 @@
 dependencies {
     api(project(":kudos-ability:kudos-ability-data:kudos-ability-data-rdb:kudos-ability-data-rdb-jdbc"))
     api(libs.spring.boot.starter.flyway)
+    api(libs.flyway.database.postgresql)
     api(libs.baomidou.dynamic.datasource.starter)
 
     // h2

--- a/kudos-ability/kudos-ability-data/kudos-ability-data-rdb/kudos-ability-data-rdb-flyway/resources/kudos-ability-data-rdb-flyway.yml
+++ b/kudos-ability/kudos-ability-data/kudos-ability-data-rdb/kudos-ability-data-rdb-flyway/resources/kudos-ability-data-rdb-flyway.yml
@@ -1,28 +1,37 @@
 kudos:
   ability:
     flyway:
-      #fly数据源配置
+      # ds → modules mapping; values accept either a CSV string or a YAML list
       datasource-config:
-        #demo：代表resource下db/{demo}/模块,对应的jdbc多数据源的数据源名
-        demo: master
+        # data source "master" runs the SQL scripts under module "demo"
+        master: demo
+      # Optional: override data source execution order; unlisted entries keep their original
+      # relative order from datasource-config and follow at the end.
+      # execution-order:
+      #   - master
+      # Optional: enable auto-scan; at startup classpath:sql/* is scanned, and every discovered
+      # module MUST appear in datasource-config — otherwise startup aborts. Auto only relaxes
+      # discovery; the ds mapping decision is never relaxed.
+      auto-config:
+        enabled: false
 
 spring:
   flyway:
-    # 启用Flyway功能
+    # Enable Flyway
     enabled: true
-    # 禁用Flyway的clean命令，使用clean命令会删除schema下的所有表
+    # Disable Flyway's clean command (clean drops all tables under the schema)
     clean-disabled: true
-    # 在执行migrate命令时需要有flyway_schema_history表，通过baseline命令可以生成该表
+    # `migrate` needs a flyway_schema_history table; `baseline` creates it if missing
     baseline-on-migrate: true
-    # 指定baseline版本号，低于该版本的SQL脚本在migrate是不会执行
+    # Baseline version; scripts with a lower version are not executed by migrate
     baseline-version: 0
-    # 设置字符编码
+    # Character encoding
     encoding: UTF-8
-    # 不允许不按顺序迁移
+    # Disallow out-of-order migration
     out-of-order: false
-    # 设置Flyway管控的schema，不设置的话为datasourcel.url中指定的schema
+    # Schema(s) managed by Flyway; defaults to the schema in datasource.url when unset
     #schemas: yt-boss
-    # 执行migrate时开启校验
+    # Validate migrations on migrate
     validate-on-migrate: false
-    # 是否进行占位符替换
+    # Placeholder replacement
     placeholder-replacement: false

--- a/kudos-ability/kudos-ability-data/kudos-ability-data-rdb/kudos-ability-data-rdb-flyway/src/io/kudos/ability/data/rdb/flyway/init/FlywayAutoConfiguration.kt
+++ b/kudos-ability/kudos-ability-data/kudos-ability-data-rdb/kudos-ability-data-rdb-flyway/src/io/kudos/ability/data/rdb/flyway/init/FlywayAutoConfiguration.kt
@@ -10,9 +10,11 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.boot.flyway.autoconfigure.FlywayMigrationStrategy
 import org.springframework.boot.flyway.autoconfigure.FlywayProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
 import org.springframework.context.annotation.PropertySource
 
 /**
@@ -21,6 +23,10 @@ import org.springframework.context.annotation.PropertySource
  * Wired after [JdbcAutoConfiguration] (once dynamic data sources are ready); via `initMethod="migrate"`,
  * [FlywayMultiDataSourceMigrator] runs migrations as soon as the bean is created. Setting
  * `kudos.ability.flyway.enabled=false` disables everything (e.g. read-only replicas / offline ops).
+ *
+ * [FlywayPreConfiguration] + [FlywayModuleStrategy] are imported here to suppress Spring Boot's
+ * default Flyway behavior (it would otherwise try to migrate `classpath:db/migration` against the
+ * primary data source).
  *
  * @author K
  * @author AI: Codex
@@ -34,6 +40,7 @@ import org.springframework.context.annotation.PropertySource
 )
 @EnableConfigurationProperties(FlywayProperties::class)
 @ConditionalOnProperty(prefix = "kudos.ability.flyway", name = ["enabled"], havingValue = "true", matchIfMissing = true)
+@Import(FlywayPreConfiguration::class)
 open class FlywayAutoConfiguration : IComponentInitializer {
 
     /**
@@ -48,12 +55,20 @@ open class FlywayAutoConfiguration : IComponentInitializer {
     /**
      * Multi-data-source configuration bean, mapped to `kudos.ability.flyway.*` in yml.
      * Does not overlap with Spring Boot's `spring.flyway.*`: this config only governs the
-     * "module → data source key" mapping; Flyway's own behavior (baseline / encoding / outOfOrder, etc.)
+     * "data source key → modules" mapping; Flyway's own behavior (baseline / encoding / outOfOrder, etc.)
      * is driven by [FlywayProperties].
      */
     @Bean
     @ConfigurationProperties(prefix = "kudos.ability.flyway")
     open fun flywayMultiDataSourceProperties(): FlywayMultiDataSourceProperties = FlywayMultiDataSourceProperties()
+
+    /**
+     * No-op [FlywayMigrationStrategy] that prevents Spring Boot's default migration initializer
+     * from running against the bare-bones Flyway bean defined in [FlywayPreConfiguration].
+     */
+    @Bean
+    @ConditionalOnMissingBean(FlywayMigrationStrategy::class)
+    open fun flywayMigrationStrategy(): FlywayMigrationStrategy = FlywayModuleStrategy()
 
     /** kudos component initializer name, used by [IComponentInitializer] for logging and order tracking. */
     override fun getComponentName(): String = "kudos-ability-data-rdb-flyway"

--- a/kudos-ability/kudos-ability-data/kudos-ability-data-rdb/kudos-ability-data-rdb-flyway/src/io/kudos/ability/data/rdb/flyway/init/FlywayModuleStrategy.kt
+++ b/kudos-ability/kudos-ability-data/kudos-ability-data-rdb/kudos-ability-data-rdb-flyway/src/io/kudos/ability/data/rdb/flyway/init/FlywayModuleStrategy.kt
@@ -1,0 +1,24 @@
+package io.kudos.ability.data.rdb.flyway.init
+
+import org.flywaydb.core.Flyway
+import org.springframework.boot.flyway.autoconfigure.FlywayMigrationStrategy
+
+/**
+ * No-op [FlywayMigrationStrategy] to prevent Spring Boot's [org.springframework.boot.flyway.autoconfigure.FlywayMigrationInitializer]
+ * from calling `flyway.migrate()` on the bare-bones Flyway bean wired in [FlywayPreConfiguration].
+ *
+ * Our actual migrations are driven by [io.kudos.ability.data.rdb.flyway.multidatasource.FlywayMultiDataSourceMigrator],
+ * which constructs per-module Flyway instances against the right data source. Leaving the default
+ * strategy in place would either no-op against an empty `db/migration` or, worse, run against the
+ * primary data source with confusing results.
+ *
+ * @author K
+ * @author AI: Codex
+ * @since 1.0.0
+ */
+class FlywayModuleStrategy : FlywayMigrationStrategy {
+
+    override fun migrate(flyway: Flyway) {
+        // intentionally empty — see class kdoc
+    }
+}

--- a/kudos-ability/kudos-ability-data/kudos-ability-data-rdb/kudos-ability-data-rdb-flyway/src/io/kudos/ability/data/rdb/flyway/init/FlywayPreConfiguration.kt
+++ b/kudos-ability/kudos-ability-data/kudos-ability-data-rdb/kudos-ability-data-rdb-flyway/src/io/kudos/ability/data/rdb/flyway/init/FlywayPreConfiguration.kt
@@ -1,0 +1,30 @@
+package io.kudos.ability.data.rdb.flyway.init
+
+import org.flywaydb.core.Flyway
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Suppresses Spring Boot's default Flyway autoconfig by providing a bare [Flyway] bean.
+ *
+ * Spring Boot's `FlywayAutoConfiguration$FlywayConfiguration#flyway()` is `@ConditionalOnMissingBean(Flyway.class)`,
+ * so registering our own — even an empty one — preempts it. Without this, Spring Boot would build
+ * its own Flyway against the primary data source and try to migrate `classpath:db/migration`,
+ * stepping on (or duplicating) our per-module migrations.
+ *
+ * Used together with [FlywayModuleStrategy], which neutralizes the default migration kick-off so
+ * this bean truly stays inert.
+ *
+ * @author K
+ * @author AI: Codex
+ * @since 1.0.0
+ */
+@Configuration
+@ConditionalOnProperty(prefix = "kudos.ability.flyway", name = ["enabled"], havingValue = "true", matchIfMissing = true)
+open class FlywayPreConfiguration {
+
+    /** Bare-bones Flyway bean — never invoked, exists only to win [@ConditionalOnMissingBean]. */
+    @Bean
+    open fun flyway(): Flyway = Flyway.configure().load()
+}

--- a/kudos-ability/kudos-ability-data/kudos-ability-data-rdb/kudos-ability-data-rdb-flyway/src/io/kudos/ability/data/rdb/flyway/multidatasource/FlywayMultiDataSourceMigrator.kt
+++ b/kudos-ability/kudos-ability-data/kudos-ability-data-rdb/kudos-ability-data-rdb-flyway/src/io/kudos/ability/data/rdb/flyway/multidatasource/FlywayMultiDataSourceMigrator.kt
@@ -5,8 +5,11 @@ import io.kudos.ability.data.rdb.jdbc.datasource.DsContextProcessor
 import io.kudos.base.io.FileKit
 import io.kudos.base.io.scanner.classpath.ClassPathScanner
 import io.kudos.base.logger.LogFactory
+import io.kudos.context.config.YamlPropertySourceFactory
 import jakarta.annotation.Resource
 import org.springframework.boot.flyway.autoconfigure.FlywayProperties
+import org.springframework.core.env.ConfigurableEnvironment
+import org.springframework.core.env.EnumerablePropertySource
 import java.io.File
 
 
@@ -18,17 +21,21 @@ import java.io.File
  *    `sql/<moduleName>/<dbType>/V1.0.1__xxx.sql`, where `<dbType>` is the lowercase form of
  *    `io.kudos.ability.data.rdb.jdbc.consts.RdbTypeEnum#name`.
  * 2. SQL script filenames follow the Flyway convention (V_x__xxx.sql / R__xxx.sql ...).
- * 3. Module upgrade order is determined by the declaration order of `kudos.ability.flyway.datasource-config`.
- * 4. If at startup a module name is found on the classpath more than once (e.g. spread across
- *    multiple jars), startup aborts with an error.
- * 5. If any module's migration fails, the remaining modules' upgrades are interrupted (the
- *    exception thrown by [FlywayKit] propagates).
- * 6. Supports upgrading multiple relational databases of different types in one pass (dbType is
- *    detected from each module's data source metadata).
+ * 3. The migration plan is `dataSource → [modules]`; within a data source modules run in
+ *    declaration order; across data sources, the order follows [FlywayMultiDataSourceProperties.executionOrder]
+ *    when set, otherwise the declaration order of `datasource-config`.
+ * 4. In **manual mode** (`auto-config.enabled=false`, default) only modules listed in
+ *    `datasource-config` are migrated; missing-on-disk modules are warned and skipped.
+ * 5. In **auto mode** (`auto-config.enabled=true`) every `sql/<x>/` directory on the classpath
+ *    must appear under some data source in `datasource-config`; otherwise startup aborts
+ *    (the assumption being that auto only relaxes scanning, not the ds mapping decision).
+ * 6. If a module name appears under multiple classpath URLs (e.g. spread across jars), startup
+ *    aborts — Flyway can't reconcile a single history table sourced from two origins.
+ * 7. Any module's migration failure interrupts the rest (exception from [FlywayKit] propagates).
+ * 8. Supports different RDB types in one pass (`dbType` is detected from each module's data source).
  *
- * Coupling point: concrete data source instances are obtained via [DsContextProcessor], so this
- * currently **depends on the dynamic-routing data source provided by the baomidou
- * dynamic-datasource starter**.
+ * Coupling: data source instances are resolved via [DsContextProcessor], so this currently
+ * **depends on the dynamic-routing data source provided by the baomidou dynamic-datasource starter**.
  *
  * @author K
  * @author AI: Codex
@@ -45,56 +52,140 @@ open class FlywayMultiDataSourceMigrator {
     @Resource
     private lateinit var dsContextProcessor: DsContextProcessor
 
+    @Resource
+    private lateinit var environment: ConfigurableEnvironment
+
     private val log = LogFactory.getLog(this::class)
 
     /**
-     * Main entry point: scan the classpath, reconcile with the modules declared in properties,
-     * and upgrade modules one by one in order. Any module failure propagates (no swallow), so
-     * Spring startup is interrupted.
+     * Main entry point: scan the classpath, reconcile with declared `datasource-config`, build
+     * an ordered `ds → [modules]` plan, then migrate. Any per-module failure propagates so Spring
+     * startup is interrupted instead of running against a half-migrated schema.
      */
     fun migrate() {
-        val moduleNamesOnDisk = scanModuleNamesFromClasspath()
-        val configuredModules = flywayMultiDatasourceProperties.datasourceConfig.sequencedKeySet()
-
-        val orphanModules = configuredModules - moduleNamesOnDisk
-        if (orphanModules.isNotEmpty()) {
-            log.warn("The following modules configured in kudos.ability.flyway.datasource-config do not actually exist under the sql directory: $orphanModules")
+        val plan = buildExecutionPlan()
+        if (plan.isEmpty()) {
+            log.info("kudos-ability-data-rdb-flyway: no Flyway modules to execute (no sql/<module>/ on classpath, or datasource-config is empty)")
+            return
         }
-
-        val toMigrate = configuredModules - orphanModules
-        toMigrate.forEach { module ->
-            val datasourceKey = checkNotNull(flywayMultiDatasourceProperties.getDataSourceKey(module)) {
-                "datasource key missing for module: $module"
-            }
-            migrateByModule(module, datasourceKey)
+        val totalModules = plan.values.sumOf { it.size }
+        log.info("kudos-ability-data-rdb-flyway: discovered $totalModules Flyway module(s); execution plan by data source: $plan")
+        plan.forEach { (ds, modules) ->
+            modules.forEach { module -> migrateByModule(module, ds) }
         }
     }
 
     /**
-     * Scan direct subdirectories of `sql/` on the classpath and filter to module names that are
-     * both on disk and in properties.
+     * Single-module entry. Looks up the configured data source for [moduleName] from
+     * `datasource-config` and migrates that one module. If the module has no configured data
+     * source, throws with a hint pointing at the originating yml file(s) — see
+     * [resolveDatasourceConfigSources].
+     */
+    fun migrateByModule(moduleName: String) {
+        val datasourceKey = flywayMultiDatasourceProperties.getDataSourceKey(moduleName)
+            ?: run {
+                val sources = resolveDatasourceConfigSources().ifEmpty { listOf("unknown") }
+                error("Module [$moduleName] has no data source configured under kudos.ability.flyway.datasource-config (configuration sources: $sources)")
+            }
+        migrateByModule(moduleName, datasourceKey)
+    }
+
+    /**
+     * 2-arg variant: validates that [datasourceKey] actually exists in the dynamic routing table
+     * before handing off to [FlywayKit]. Exposed `internal` so tests and adjacent callers (e.g.
+     * code generators inside the same module) can drive a specific (module, ds) pair.
+     */
+    internal fun migrateByModule(moduleName: String, datasourceKey: String) {
+        if (!dsContextProcessor.haveDataSource(datasourceKey)) {
+            val sources = resolveDatasourceConfigSources().ifEmpty { listOf("unknown") }
+            val errMsg = "The data source [$datasourceKey] configured for module [$moduleName] does not exist! All subsequent database updates are aborted! (configuration sources: $sources)"
+            log.error(errMsg)
+            error(errMsg)
+        }
+
+        val dataSource = checkNotNull(dsContextProcessor.getDataSource(datasourceKey)) {
+            "Data source [$datasourceKey] resolved to null"
+        }
+        FlywayKit.migrate(moduleName, dataSource, flywayProperties)
+    }
+
+    /**
+     * Build the ordered `ds → [modules]` plan.
      *
-     * Duplicate-detection semantics: if a module of the same name appears under multiple classpath
-     * URLs (different jars / different source sets), an [IllegalStateException] is thrown. Flyway
-     * does not support a single schema history table sourced from two different origins, so this
-     * is treated as a fatal error to avoid confused migrations at runtime.
+     * - Manual mode: keep only the intersection of (configured ∩ on-disk); orphans declared but
+     *   missing on disk are warned and skipped; modules on disk but absent from config are
+     *   silently ignored.
+     * - Auto mode: every on-disk module must appear in some ds entry; otherwise abort (treat
+     *   missing mapping as a configuration bug rather than guessing a primary data source).
+     *
+     * Final ordering applies [FlywayMultiDataSourceProperties.executionOrder] when present.
+     */
+    private fun buildExecutionPlan(): LinkedHashMap<String, List<String>> {
+        val configured = flywayMultiDatasourceProperties.getDatasourceModules()
+        val auto = flywayMultiDatasourceProperties.autoConfig.enabled
+        val moduleNamesOnDisk = scanModuleNamesFromClasspath()
+
+        if (auto) {
+            val configuredModules = configured.values.flatten().toSet()
+            val unmapped = moduleNamesOnDisk - configuredModules
+            if (unmapped.isNotEmpty()) {
+                val sources = resolveDatasourceConfigSources().ifEmpty { listOf("unknown") }
+                error(
+                    "kudos.ability.flyway.auto-config.enabled=true requires every classpath sql/<module>/ to be declared under datasource-config." +
+                        " Missing mapping for module(s): $unmapped (configuration sources: $sources)"
+                )
+            }
+        }
+
+        val plan = linkedMapOf<String, List<String>>()
+        configured.forEach { (ds, modules) ->
+            val (onDisk, orphan) = modules.partition { it in moduleNamesOnDisk }
+            if (orphan.isNotEmpty()) {
+                log.warn("Modules configured for data source [$ds] not found under classpath sql/: $orphan")
+            }
+            if (onDisk.isNotEmpty()) plan[ds] = onDisk
+        }
+        return applyExecutionOrder(plan)
+    }
+
+    /**
+     * Reorder data sources according to [FlywayMultiDataSourceProperties.executionOrder]. Listed
+     * keys come first in the given order; unlisted keys keep their original relative order and
+     * follow at the end; entries in the order list that don't exist in [plan] are dropped.
+     */
+    private fun applyExecutionOrder(plan: LinkedHashMap<String, List<String>>): LinkedHashMap<String, List<String>> {
+        val order = flywayMultiDatasourceProperties.executionOrder
+        if (order.isEmpty()) return plan
+        val remaining = LinkedHashSet(plan.keys)
+        val ordered = LinkedHashMap<String, List<String>>()
+        order.forEach { ds ->
+            val key = ds.trim()
+            if (key.isBlank()) return@forEach
+            if (remaining.remove(key)) {
+                ordered[key] = plan.getValue(key)
+            }
+        }
+        remaining.forEach { ordered[it] = plan.getValue(it) }
+        return ordered
+    }
+
+    /**
+     * Scan direct subdirectories of `sql/` on the classpath. Duplicate-detection semantics:
+     * if a module name appears under multiple classpath URLs (different jars / source sets),
+     * an [IllegalStateException] is thrown — Flyway can't merge two origins into a single
+     * schema history table.
      */
     private fun scanModuleNamesFromClasspath(): Set<String> {
         val sqlRootPath = FlywayKit.SQL_ROOT_PATH
         val locationUrls = ClassPathScanner.getLocationUrlsForPath(sqlRootPath)
-        val moduleNames = mutableSetOf<String>()
+        val moduleNames = linkedSetOf<String>()
         locationUrls.forEach { url ->
             val childFolders = listChildFolders(url, sqlRootPath)
             childFolders.forEach { moduleName ->
                 if (moduleNames.contains(moduleName)) {
                     error("Multiple modules named [$moduleName] exist! Please check whether the classpath contains duplicate sql/$moduleName directories.")
                 }
-                val datasourceKey = flywayMultiDatasourceProperties.getDataSourceKey(moduleName)
-                if (!datasourceKey.isNullOrBlank()) {
-                    moduleNames.add(moduleName)
-                } else {
-                    log.warn("No data source configured for module [$moduleName]! Ignored. Module location: ${url.path}/$moduleName")
-                }
+                moduleNames.add(moduleName)
             }
         }
         return moduleNames
@@ -114,20 +205,21 @@ open class FlywayMultiDataSourceMigrator {
     }
 
     /**
-     * Single-module upgrade. First verifies that the data source key really exists in the dynamic
-     * routing table, then delegates to [FlywayKit]. If the data source does not exist an
-     * [IllegalStateException] is thrown; the caller decides whether to abort/retry.
+     * Locate which yml file(s) contributed any `kudos.ability.flyway.datasource-config.*` entry.
+     * Used in error messages to help debug multi-jar deployments where the offending value may
+     * have come from a dependency's yml rather than the application's. Relies on
+     * [YamlPropertySourceFactory.getSourceMap] populated as yml files are loaded.
      */
-    internal fun migrateByModule(moduleName: String, datasourceKey: String) {
-        if (!dsContextProcessor.haveDataSource(datasourceKey)) {
-            val errMsg = "The data source [$datasourceKey] configured for module [$moduleName] does not exist! All subsequent database updates are aborted!"
-            log.error(errMsg)
-            error(errMsg)
+    private fun resolveDatasourceConfigSources(): List<String> {
+        val prefix = "kudos.ability.flyway.datasource-config."
+        val sourceMap = YamlPropertySourceFactory.getSourceMap()
+        val locations = linkedSetOf<String>()
+        for (propertySource in environment.propertySources) {
+            if (propertySource !is EnumerablePropertySource<*>) continue
+            val matched = propertySource.propertyNames.any { it.startsWith(prefix) }
+            if (!matched) continue
+            locations.add(sourceMap[propertySource.name] ?: propertySource.name)
         }
-
-        val dataSource = checkNotNull(dsContextProcessor.getDataSource(datasourceKey)) {
-            "Data source [$datasourceKey] resolved to null"
-        }
-        FlywayKit.migrate(moduleName, dataSource, flywayProperties)
+        return locations.toList()
     }
 }

--- a/kudos-ability/kudos-ability-data/kudos-ability-data-rdb/kudos-ability-data-rdb-flyway/src/io/kudos/ability/data/rdb/flyway/multidatasource/FlywayMultiDataSourceProperties.kt
+++ b/kudos-ability/kudos-ability-data/kudos-ability-data-rdb/kudos-ability-data-rdb-flyway/src/io/kudos/ability/data/rdb/flyway/multidatasource/FlywayMultiDataSourceProperties.kt
@@ -3,13 +3,27 @@ package io.kudos.ability.data.rdb.flyway.multidatasource
 /**
  * Multi-data-source Flyway configuration properties, mapped to `kudos.ability.flyway.*` in yml.
  *
- * Primarily carries the "module name → data source key" mapping [datasourceConfig]; at startup
- * [FlywayMultiDataSourceMigrator] uses it to decide which modules need migration and which data
- * source to use.
+ * Direction: **data source key → list of module names**. A single data source may host multiple
+ * modules, declared as either a CSV string or a YAML list. Declaration order is preserved
+ * ([LinkedHashMap]); within a single data source, modules migrate in that order. Across data
+ * sources, migration order follows the declaration order of [datasourceConfig], unless
+ * [executionOrder] explicitly overrides it.
  *
- * Uses [LinkedHashMap] to preserve declaration order — within a single startup cycle modules are
- * migrated in the order declared in yml, which makes it easy to express explicit dependencies like
- * "module A's schema must land before module B's".
+ * Example yml:
+ * ```yaml
+ * kudos:
+ *   ability:
+ *     flyway:
+ *       datasource-config:
+ *         master: sys,tenant     # CSV form
+ *         audit:                 # list form
+ *           - audit_log
+ *       execution-order:         # optional explicit ordering
+ *         - master
+ *         - audit
+ *       auto-config:
+ *         enabled: false         # if true, all sql/<x>/ on classpath must be declared above
+ * ```
  *
  * @author K
  * @author AI: Codex
@@ -17,9 +31,78 @@ package io.kudos.ability.data.rdb.flyway.multidatasource
  */
 open class FlywayMultiDataSourceProperties {
 
-    /** Data source configuration: key = module name (matches the `sql/<moduleName>/` directory), value = dynamic data source key. */
-    var datasourceConfig: LinkedHashMap<String, String> = linkedMapOf()
+    /**
+     * Data source → module list. Value accepts a CSV string (`"sys,tenant"`) or a YAML list
+     * (`- sys`, `- tenant`); both are normalized by [getDatasourceModules].
+     */
+    var datasourceConfig: LinkedHashMap<String, Any?> = linkedMapOf()
 
-    /** Returns the data source key for the given module; returns `null` if the module is not configured. */
-    fun getDataSourceKey(moduleName: String): String? = datasourceConfig[moduleName]
+    /**
+     * Optional override of data-source execution order. When non-empty, listed keys run first in
+     * the given order; data sources not listed keep their declaration order and follow at the end.
+     * Entries that don't match any key in [datasourceConfig] are silently ignored.
+     */
+    var executionOrder: List<String> = emptyList()
+
+    /** Auto-discovery toggle (see [AutoConfig]). */
+    var autoConfig: AutoConfig = AutoConfig()
+
+    /**
+     * Normalized view: data source → list of modules (declaration order). Values are parsed from
+     * CSV or List into [List]<[String]>. Reserved keys (see [isReservedDatasourceConfigKey]) are
+     * filtered out to defend against YAML mis-indentation (e.g. `execution-order` accidentally
+     * nested under `datasource-config`).
+     */
+    fun getDatasourceModules(): LinkedHashMap<String, List<String>> {
+        val result = LinkedHashMap<String, List<String>>()
+        datasourceConfig.forEach { (ds, modules) ->
+            if (isReservedDatasourceConfigKey(ds)) return@forEach
+            result[ds] = parseModules(modules)
+        }
+        return result
+    }
+
+    /** Returns the data source key hosting [moduleName], or `null` if no entry contains it. */
+    fun getDataSourceKey(moduleName: String): String? {
+        getDatasourceModules().forEach { (ds, modules) ->
+            if (moduleName in modules) return ds
+        }
+        return null
+    }
+
+    /**
+     * Accepts CSV string, YAML list, or null. When a YAML list sits under a `Map<String, Any?>`
+     * value, Spring Boot's relaxed binder flattens it to an indexed `LinkedHashMap` (e.g.
+     * `{0=moduleX, 1=other}`); the [Map] branch handles that case by taking `values()` in
+     * insertion order. Blanks are trimmed and dropped.
+     */
+    private fun parseModules(value: Any?): List<String> = when (value) {
+        null -> emptyList()
+        is Iterable<*> -> value.mapNotNull { it?.toString()?.trim() }.filter { it.isNotEmpty() }
+        is Map<*, *> -> value.values.mapNotNull { it?.toString()?.trim() }.filter { it.isNotEmpty() }
+        else -> value.toString()
+            .split(",")
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+    }
+
+    /** Auto-config toggle. When `enabled=true` every module discovered on classpath must appear in [datasourceConfig]. */
+    open class AutoConfig {
+        var enabled: Boolean = false
+    }
+
+    companion object {
+        /**
+         * Same name as [executionOrder]; protects against YAML mis-indentation where the list ends
+         * up flattened under `datasource-config` (e.g. `datasource-config.execution-order[0]`).
+         */
+        const val EXECUTION_ORDER_RESERVED_KEY = "execution-order"
+
+        /** Whether [key] is a reserved property name accidentally captured under `datasource-config`. */
+        fun isReservedDatasourceConfigKey(key: String?): Boolean {
+            if (key.isNullOrBlank()) return false
+            return key == EXECUTION_ORDER_RESERVED_KEY
+                || key.startsWith("$EXECUTION_ORDER_RESERVED_KEY[")
+        }
+    }
 }

--- a/kudos-ability/kudos-ability-data/kudos-ability-data-rdb/kudos-ability-data-rdb-flyway/test-resources/application.yml
+++ b/kudos-ability/kudos-ability-data/kudos-ability-data-rdb/kudos-ability-data-rdb-flyway/test-resources/application.yml
@@ -65,12 +65,18 @@ spring:
 kudos:
   ability:
     flyway:
-      #fly数据源配置
+      # New structure: ds → modules (CSV or list form)
       datasource-config:
-        #demo：代表resource下db/{demo}/模块,对应的jdbc多数据源的数据源名
-        module1: ds1
-        module2: ds1
-        moduleX: no_exists
+        ds1: module1,module2   # module2 has no scripts on disk → should warn only, not fail
+        no_exists:             # intentionally points at a non-existent ds for the negative test
+          - moduleX
+      # Optional ds execution order; here we explicitly assert ds1 runs first
+      # (which already matches the declaration order).
+      execution-order:
+        - ds1
+        - no_exists
+      auto-config:
+        enabled: false
 
 logging:
   level:

--- a/kudos-ability/kudos-ability-data/kudos-ability-data-rdb/kudos-ability-data-rdb-flyway/test-src/io/kudos/ability/data/rdb/flyway/FlywayTest.kt
+++ b/kudos-ability/kudos-ability-data/kudos-ability-data-rdb/kudos-ability-data-rdb-flyway/test-src/io/kudos/ability/data/rdb/flyway/FlywayTest.kt
@@ -1,18 +1,21 @@
 package io.kudos.ability.data.rdb.flyway
 
 import io.kudos.ability.data.rdb.flyway.multidatasource.FlywayMultiDataSourceMigrator
+import io.kudos.ability.data.rdb.flyway.multidatasource.FlywayMultiDataSourceProperties
 import io.kudos.ability.data.rdb.jdbc.datasource.DsContextProcessor
 import io.kudos.test.common.init.EnableKudosTest
 import jakarta.annotation.Resource
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 /**
  * Integration tests for [FlywayMultiDataSourceMigrator]. Covers:
  * - happy path: full migration → tables exist and initial data is inserted; calling migrate() twice within the same process is idempotent
- * - failure branch when the data source key does not exist
+ * - failure branch when the data source key does not exist (resolved via single-arg `migrateByModule`)
  * - Spring Boot `spring.flyway.placeholders` propagates to Flyway scripts
+ * - CSV/list parsing + execution-order ordering (validated via the Properties bean)
  *
  * @author K
  * @author AI: Codex
@@ -27,6 +30,8 @@ class FlywayTest {
     @Resource
     private lateinit var dsContextProcessor: DsContextProcessor
 
+    @Resource
+    private lateinit var properties: FlywayMultiDataSourceProperties
 
     /**
      * Runs the full migration flow: invoke [FlywayMultiDataSourceMigrator.migrate] twice to verify
@@ -52,21 +57,55 @@ class FlywayTest {
     }
 
     /**
-     * Error path for the single-module entry point: passing a non-existent data source key must
-     * throw an exception and abort the migration.
+     * Error path for the single-module entry point: moduleX is configured under a non-existent
+     * data source (`no_exists`); calling [FlywayMultiDataSourceMigrator.migrateByModule] must
+     * resolve the ds, find it missing in the dynamic routing table, and throw.
      */
     @Test
-    fun migrateByModule() {
-        // Data source key does not exist; should throw and abort
-        assertFailsWith<RuntimeException> { migrator.migrateByModule("module3", "no_exists") }
+    fun migrateByModuleMissingDataSource() {
+        assertFailsWith<RuntimeException> { migrator.migrateByModule("moduleX") }
     }
 
-//    companion object Companion {
-//        @JvmStatic
-//        @DynamicPropertySource
-//        private fun changeProperties(registry: DynamicPropertyRegistry) {
-//            H2TestContainer.startIfNeeded(registry)
-//        }
-//    }
+    /**
+     * Error path: a module name that's not declared anywhere in datasource-config triggers the
+     * "no data source configured" branch (with a source-tracing hint in the message).
+     */
+    @Test
+    fun migrateByModuleUnknownModule() {
+        assertFailsWith<RuntimeException> { migrator.migrateByModule("never_configured_module") }
+    }
 
+    /**
+     * Properties layer: CSV value is parsed into a list, list value stays a list, and reverse
+     * lookup ([FlywayMultiDataSourceProperties.getDataSourceKey]) finds the hosting data source.
+     */
+    @Test
+    fun propertiesParseAndReverseLookup() {
+        val ds1Modules = properties.getDatasourceModules()["ds1"]
+        assertEquals(listOf("module1", "module2"), ds1Modules)
+        val noExistsModules = properties.getDatasourceModules()["no_exists"]
+        assertEquals(listOf("moduleX"), noExistsModules)
+        assertEquals("ds1", properties.getDataSourceKey("module1"))
+        assertEquals("no_exists", properties.getDataSourceKey("moduleX"))
+        assertEquals(null, properties.getDataSourceKey("never_configured_module"))
+    }
+
+    /**
+     * Properties layer: `execution-order` overrides default ordering; here both ds keys are
+     * listed and should keep the order ds1 → no_exists (matches yml declaration in this case).
+     */
+    @Test
+    fun executionOrderHonored() {
+        assertEquals(listOf("ds1", "no_exists"), properties.executionOrder)
+    }
+
+    /**
+     * Properties layer: defensive guard so a mis-indented `execution-order` under
+     * `datasource-config` is not interpreted as a data source name.
+     */
+    @Test
+    fun reservedKeyDefense() {
+        assertTrue(FlywayMultiDataSourceProperties.isReservedDatasourceConfigKey("execution-order"))
+        assertTrue(FlywayMultiDataSourceProperties.isReservedDatasourceConfigKey("execution-order[0]"))
+    }
 }


### PR DESCRIPTION
Brings kudos-ability-data-rdb-flyway up to parity with the soul counterpart.

- datasource-config now maps ds → modules (CSV or YAML list), inverting the previous module → ds direction; values are parsed at read time and tolerate Spring Boot's indexed-map flattening of YAML lists.
- New auto-config.enabled mode scans classpath:sql/* and requires every discovered module to have a ds mapping (auto only relaxes discovery, not the mapping decision).
- New execution-order overrides cross-ds execution order; unlisted entries keep their original relative order and follow at the end.
- Single-arg migrateByModule(name) resolves the ds from config.
- FlywayPreConfiguration + FlywayModuleStrategy suppress Spring Boot's default Flyway (which would migrate classpath:db/migration against the primary data source).
- Errors point at which yml file contributed the offending config via YamlPropertySourceFactory.getSourceMap(), and isReservedDatasourceConfigKey defends against YAML mis-indentation of execution-order.
- libs.versions.toml + build.gradle.kts add flyway-database-postgresql (Flyway 10+ split out the PG adapter; without it PG 18 startup throws "Unsupported Database").