### PR TITLE
Add 4 auth aggregator endpoints (replaces console-UI N+1 fan-outs)

### DIFF
--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-api-admin/src/io/kudos/ms/auth/api/admin/controller/group/AuthGroupAdminController.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-api-admin/src/io/kudos/ms/auth/api/admin/controller/group/AuthGroupAdminController.kt
@@ -1,12 +1,15 @@
 package io.kudos.ms.auth.api.admin.controller.group
 
 import io.kudos.ability.web.springmvc.controller.BaseCrudController
+import io.kudos.ms.auth.common.group.vo.request.AuthGroupBatchBindUsersRequest
 import io.kudos.ms.auth.common.group.vo.request.AuthGroupFormCreate
 import io.kudos.ms.auth.common.group.vo.request.AuthGroupFormUpdate
 import io.kudos.ms.auth.common.group.vo.request.AuthGroupQuery
 import io.kudos.ms.auth.common.group.vo.response.AuthGroupDetail
 import io.kudos.ms.auth.common.group.vo.response.AuthGroupEdit
 import io.kudos.ms.auth.common.group.vo.response.AuthGroupRow
+import io.kudos.ms.auth.common.group.vo.response.GroupDeleteImpactVo
+import io.kudos.ms.auth.common.role.vo.response.BatchBindResultVo
 import io.kudos.ms.auth.core.group.service.iservice.IAuthGroupRoleService
 import io.kudos.ms.auth.core.group.service.iservice.IAuthGroupService
 import io.kudos.ms.auth.core.group.service.iservice.IAuthGroupUserService
@@ -80,5 +83,26 @@ class AuthGroupAdminController :
     @DeleteMapping("/unbindRole")
     fun unbindRole(@RequestParam groupId: String, @RequestParam roleId: String): Boolean =
         authGroupRoleService.unbind(groupId, roleId)
+
+    // -- Aggregators ------------------------------------------------------------
+    //
+    // Mirror of the admin endpoints on AuthRoleAdminController; same rationale (single round
+    // trip in place of an N+M fan-out from the console UI).
+
+    /**
+     * Pre-delete impact summary across a batch of groups: distinct counts of users currently
+     * belonging to, and roles currently granted by, any group in the supplied list.
+     */
+    @PostMapping("/getDeleteImpact")
+    fun getDeleteImpact(@RequestBody groupIds: List<String>): GroupDeleteImpactVo =
+        service.getDeleteImpact(groupIds)
+
+    /**
+     * Cartesian-product batch-bind for groups: every user in `userIds` is added to every group
+     * in `groupIds`. Per-group transactional boundary — partial failures returned in the response.
+     */
+    @PostMapping("/batchBindUsers")
+    fun batchBindUsers(@RequestBody request: AuthGroupBatchBindUsersRequest): BatchBindResultVo =
+        service.batchBindUsers(request.groupIds, request.userIds)
 
 }

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-api-admin/src/io/kudos/ms/auth/api/admin/controller/role/AuthRoleAdminController.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-api-admin/src/io/kudos/ms/auth/api/admin/controller/role/AuthRoleAdminController.kt
@@ -1,12 +1,17 @@
 package io.kudos.ms.auth.api.admin.controller.role
 
 import io.kudos.ability.web.springmvc.controller.BaseCrudController
+import io.kudos.ms.auth.common.role.vo.request.AuthRoleBatchBindUsersRequest
+import io.kudos.ms.auth.common.role.vo.request.AuthRoleCopyRequest
 import io.kudos.ms.auth.common.role.vo.request.AuthRoleFormCreate
 import io.kudos.ms.auth.common.role.vo.request.AuthRoleFormUpdate
 import io.kudos.ms.auth.common.role.vo.request.AuthRoleQuery
 import io.kudos.ms.auth.common.role.vo.response.AuthRoleDetail
 import io.kudos.ms.auth.common.role.vo.response.AuthRoleEdit
 import io.kudos.ms.auth.common.role.vo.response.AuthRoleRow
+import io.kudos.ms.auth.common.role.vo.response.BatchBindResultVo
+import io.kudos.ms.auth.common.role.vo.response.EffectivePermissionsVo
+import io.kudos.ms.auth.common.role.vo.response.RoleDeleteImpactVo
 import io.kudos.ms.auth.core.role.service.iservice.IAuthRoleResourceService
 import io.kudos.ms.auth.core.role.service.iservice.IAuthRoleService
 import io.kudos.ms.auth.core.role.service.iservice.IAuthRoleUserService
@@ -84,5 +89,45 @@ class AuthRoleAdminController :
     @DeleteMapping("/unbindResource")
     fun unbindResource(@RequestParam roleId: String, @RequestParam resourceId: String): Boolean =
         authRoleResourceService.unbind(roleId, resourceId)
+
+    // -- Aggregators ------------------------------------------------------------
+    //
+    // Each of the four endpoints below replaces an N+M+K fan-out the console UI was making
+    // pre-aggregator. They are HTTP-thin: the heavy lifting (transaction boundaries, cache
+    // composition, partial-failure aggregation) lives in IAuthRoleService.
+
+    /**
+     * One-shot snapshot of a user's effective permissions (direct roles + groups + inherited
+     * roles + resources). Replaces the AccountEffectivePermissionsDialog's 1 + 1 + N + M + 3
+     * fan-out with a single round trip.
+     */
+    @GetMapping("/getEffectivePermissions")
+    fun getEffectivePermissions(@RequestParam userId: String): EffectivePermissionsVo =
+        service.getEffectivePermissions(userId)
+
+    /**
+     * Pre-delete impact summary across a batch of roles: distinct counts of users and groups
+     * currently bound to any of the supplied [roleIds]. Body is a JSON array of role ids.
+     */
+    @PostMapping("/getDeleteImpact")
+    fun getDeleteImpact(@RequestBody roleIds: List<String>): RoleDeleteImpactVo =
+        service.getDeleteImpact(roleIds)
+
+    /**
+     * Cartesian-product batch-bind: every user in `userIds` is bound to every role in `roleIds`.
+     * Per-role transactional boundary — partial failures are returned in the response payload
+     * rather than rolled back.
+     */
+    @PostMapping("/batchBindUsers")
+    fun batchBindUsers(@RequestBody request: AuthRoleBatchBindUsersRequest): BatchBindResultVo =
+        service.batchBindUsers(request.roleIds, request.userIds)
+
+    /**
+     * Atomic role-copy: read source, save new role (overriding `code`/`name`), optionally copy
+     * resource grants — all in one transaction. Returns the new role id.
+     */
+    @PostMapping("/copyRole")
+    fun copyRole(@RequestBody request: AuthRoleCopyRequest): String =
+        service.copyRole(request.sourceId, request.code, request.name, request.copyResources)
 
 }

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/group/vo/request/AuthGroupBatchBindUsersRequest.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/group/vo/request/AuthGroupBatchBindUsersRequest.kt
@@ -1,0 +1,22 @@
+package io.kudos.ms.auth.common.group.vo.request
+
+import java.io.Serializable
+
+/**
+ * Request body for group↔users batch bind. Mirrors [io.kudos.ms.auth.common.role.vo.request.AuthRoleBatchBindUsersRequest]
+ * for groups.
+ *
+ * @author K
+ * @author AI: Claude
+ * @since 1.0.0
+ */
+data class AuthGroupBatchBindUsersRequest(
+    /** Group ids to bind into. */
+    val groupIds: List<String>,
+    /** User ids that should be bound to **every** group in [groupIds]. */
+    val userIds: List<String>,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/group/vo/response/GroupDeleteImpactVo.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/group/vo/response/GroupDeleteImpactVo.kt
@@ -1,0 +1,27 @@
+package io.kudos.ms.auth.common.group.vo.response
+
+import java.io.Serializable
+
+/**
+ * Aggregate delete-impact summary for a batch of user groups.
+ *
+ * Counts are over the union of bindings — i.e. if two groups both contain user U, U is counted
+ * once in [users]. Same de-dup rule for [roles].
+ *
+ * @author K
+ * @author AI: Claude
+ * @since 1.0.0
+ */
+data class GroupDeleteImpactVo(
+    /** Distinct users currently belonging to any group in the request. */
+    val users: Int,
+    /** Distinct roles currently granted by any group in the request. */
+    val roles: Int,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+
+        @JvmStatic
+        fun zero(): GroupDeleteImpactVo = GroupDeleteImpactVo(users = 0, roles = 0)
+    }
+}

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/role/vo/request/AuthRoleBatchBindUsersRequest.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/role/vo/request/AuthRoleBatchBindUsersRequest.kt
@@ -1,0 +1,25 @@
+package io.kudos.ms.auth.common.role.vo.request
+
+import java.io.Serializable
+
+/**
+ * Request body for role↔users batch bind.
+ *
+ * Sent as a single JSON object so both lists travel in the body — the alternative (one list in
+ * the query string and one in the body) is awkward for the HTTP client wrappers used in the
+ * console UI and would limit length.
+ *
+ * @author K
+ * @author AI: Claude
+ * @since 1.0.0
+ */
+data class AuthRoleBatchBindUsersRequest(
+    /** Role ids to bind into. */
+    val roleIds: List<String>,
+    /** User ids that should be bound to **every** role in [roleIds]. */
+    val userIds: List<String>,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/role/vo/request/AuthRoleCopyRequest.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/role/vo/request/AuthRoleCopyRequest.kt
@@ -1,0 +1,29 @@
+package io.kudos.ms.auth.common.role.vo.request
+
+import java.io.Serializable
+
+/**
+ * Request body for atomic role-copy.
+ *
+ * The server reads the source role's full detail, builds a new role with [code] / [name]
+ * overridden (the rest inherited from source), inserts it, and — when [copyResources] is true —
+ * binds the source's resource grants to the new role in the same transaction.
+ *
+ * @author K
+ * @author AI: Claude
+ * @since 1.0.0
+ */
+data class AuthRoleCopyRequest(
+    /** Role to copy from. */
+    val sourceId: String,
+    /** New role's code; must be unique under the same tenant + subsystem. */
+    val code: String,
+    /** New role's name. */
+    val name: String,
+    /** When true, the source's resource grants are copied to the new role in the same transaction. */
+    val copyResources: Boolean = true,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/role/vo/response/BatchBindResultVo.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/role/vo/response/BatchBindResultVo.kt
@@ -1,0 +1,40 @@
+package io.kudos.ms.auth.common.role.vo.response
+
+import java.io.Serializable
+
+/**
+ * Result of a batch bind operation (role↔user or group↔user).
+ *
+ * Partial-success is expected behaviour: each owner's bind is a separate transaction so a
+ * single bad row doesn't block the rest. The admin UI uses [failures] to render per-owner
+ * error messages.
+ *
+ * @author K
+ * @author AI: Claude
+ * @since 1.0.0
+ */
+data class BatchBindResultVo(
+    /** Number of owners (roles or groups) whose bind succeeded. */
+    val ok: Int,
+    /** Per-owner failures. Empty when [ok] equals the request's owner count. */
+    val failures: List<BatchBindFailure>,
+) : Serializable {
+
+    data class BatchBindFailure(
+        /** Owner id (role id or group id) whose bind failed. */
+        val ownerId: String,
+        /** Human-readable failure reason — exception message, not stack trace. */
+        val reason: String,
+    ) : Serializable {
+        companion object {
+            private const val serialVersionUID = 1L
+        }
+    }
+
+    companion object {
+        private const val serialVersionUID = 1L
+
+        @JvmStatic
+        fun empty(): BatchBindResultVo = BatchBindResultVo(ok = 0, failures = emptyList())
+    }
+}

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/role/vo/response/EffectivePermissionsVo.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/role/vo/response/EffectivePermissionsVo.kt
@@ -1,0 +1,57 @@
+package io.kudos.ms.auth.common.role.vo.response
+
+import io.kudos.ms.auth.common.group.vo.AuthGroupCacheEntry
+import io.kudos.ms.auth.common.role.vo.AuthRoleCacheEntry
+import io.kudos.ms.sys.common.resource.vo.SysResourceCacheEntry
+import java.io.Serializable
+
+/**
+ * Composite "effective permissions" snapshot for a single user.
+ *
+ * Replaces the console UI's N+M+K fan-out (`listRoleIdsByUser` + `listGroupIdsByUser` +
+ * per-group `listRoleIds` + per-role `listResourceIds` + 3 separate pagingSearch hops for
+ * metadata) with one round trip. The fields are flat collections with id keys so the caller
+ * can render any view (table grouped by source, tree, etc.) without further server calls.
+ *
+ * @author K
+ * @author AI: Claude
+ * @since 1.0.0
+ */
+data class EffectivePermissionsVo(
+    /**
+     * Roles bound directly to the user (NOT including those inherited via groups). Frontend uses
+     * this set to mark rows as "Direct" in the source column.
+     */
+    val directRoles: List<AuthRoleCacheEntry>,
+
+    /**
+     * Groups the user belongs to, fully resolved (id + name + tenant + etc). Becomes the second
+     * section in the permission viewer.
+     */
+    val groups: List<AuthGroupCacheEntry>,
+
+    /**
+     * groupId → list of roles inherited via that group. A role can appear under multiple groups
+     * (and possibly also under [directRoles]); the frontend de-dups by role id and shows all the
+     * group sources as tags.
+     */
+    val rolesByGroup: Map<String, List<AuthRoleCacheEntry>>,
+
+    /**
+     * roleId → resources that role grants. A resource can appear under multiple roles; the
+     * frontend inverts this map (resource → roles) for the "Granted by" column.
+     */
+    val resourcesByRole: Map<String, List<SysResourceCacheEntry>>,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+
+        @JvmStatic
+        fun empty(): EffectivePermissionsVo = EffectivePermissionsVo(
+            directRoles = emptyList(),
+            groups = emptyList(),
+            rolesByGroup = emptyMap(),
+            resourcesByRole = emptyMap(),
+        )
+    }
+}

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/role/vo/response/RoleDeleteImpactVo.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/role/vo/response/RoleDeleteImpactVo.kt
@@ -1,0 +1,27 @@
+package io.kudos.ms.auth.common.role.vo.response
+
+import java.io.Serializable
+
+/**
+ * Aggregate delete-impact summary for a batch of roles.
+ *
+ * Counts are over the union of bindings — i.e. if two roles both grant user U, U is counted
+ * once in [users]. Same de-dup rule for [groups].
+ *
+ * @author K
+ * @author AI: Claude
+ * @since 1.0.0
+ */
+data class RoleDeleteImpactVo(
+    /** Distinct users currently bound to any role in the request. */
+    val users: Int,
+    /** Distinct groups currently bound to any role in the request. */
+    val groups: Int,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+
+        @JvmStatic
+        fun zero(): RoleDeleteImpactVo = RoleDeleteImpactVo(users = 0, groups = 0)
+    }
+}

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/src/io/kudos/ms/auth/core/group/service/impl/AuthGroupService.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/src/io/kudos/ms/auth/core/group/service/impl/AuthGroupService.kt
@@ -3,16 +3,22 @@ package io.kudos.ms.auth.core.group.service.impl
 import io.kudos.base.bean.BeanKit
 import io.kudos.base.logger.LogFactory
 import io.kudos.base.support.service.impl.BaseCrudService
+import io.kudos.ms.auth.common.group.vo.response.GroupDeleteImpactVo
+import io.kudos.ms.auth.common.role.vo.response.BatchBindResultVo
 import io.kudos.ms.auth.core.group.dao.AuthGroupDao
 import io.kudos.ms.auth.core.group.event.AuthGroupBatchDeleted
 import io.kudos.ms.auth.core.group.event.AuthGroupDeleted
 import io.kudos.ms.auth.core.group.event.AuthGroupInserted
 import io.kudos.ms.auth.core.group.event.AuthGroupUpdated
 import io.kudos.ms.auth.core.group.model.po.AuthGroup
+import io.kudos.ms.auth.core.group.service.iservice.IAuthGroupRoleService
 import io.kudos.ms.auth.core.group.service.iservice.IAuthGroupService
+import io.kudos.ms.auth.core.group.service.iservice.IAuthGroupUserService
+import jakarta.annotation.Resource
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 
 
@@ -32,6 +38,12 @@ open class AuthGroupService(
 
     @Autowired
     private lateinit var eventPublisher: ApplicationEventPublisher
+
+    @Resource
+    private lateinit var authGroupUserService: IAuthGroupUserService
+
+    @Resource
+    private lateinit var authGroupRoleService: IAuthGroupRoleService
 
     private val log = LogFactory.getLog(this::class)
 
@@ -83,6 +95,38 @@ open class AuthGroupService(
             eventPublisher.publishEvent(AuthGroupBatchDeleted(snapshots))
         }
         return count
+    }
+
+    @Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+    override fun getDeleteImpact(groupIds: Collection<String>): GroupDeleteImpactVo {
+        if (groupIds.isEmpty()) return GroupDeleteImpactVo.zero()
+        // Union over all groups: a user belonging to multiple groups in the batch counts once.
+        val allUserIds = HashSet<String>()
+        val allRoleIds = HashSet<String>()
+        for (gid in groupIds) {
+            allUserIds.addAll(authGroupUserService.getUserIdsByGroupId(gid))
+            allRoleIds.addAll(authGroupRoleService.getRoleIdsByGroupId(gid))
+        }
+        return GroupDeleteImpactVo(users = allUserIds.size, roles = allRoleIds.size)
+    }
+
+    @Transactional
+    override fun batchBindUsers(groupIds: Collection<String>, userIds: Collection<String>): BatchBindResultVo {
+        if (groupIds.isEmpty() || userIds.isEmpty()) return BatchBindResultVo.empty()
+        var ok = 0
+        val failures = mutableListOf<BatchBindResultVo.BatchBindFailure>()
+        // Per-group transaction boundary mirrors the role-side semantics; partial failure is
+        // surfaced to the admin UI rather than masked by a blanket rollback.
+        for (gid in groupIds) {
+            try {
+                authGroupUserService.batchBind(gid, userIds)
+                ok++
+            } catch (e: Exception) {
+                log.warn("Batch-bind failed for group ${gid}: ${e.message}")
+                failures += BatchBindResultVo.BatchBindFailure(ownerId = gid, reason = e.message ?: e.javaClass.simpleName)
+            }
+        }
+        return BatchBindResultVo(ok = ok, failures = failures)
     }
 
 

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/src/io/kudos/ms/auth/core/group/service/iservice/IAuthGroupService.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/src/io/kudos/ms/auth/core/group/service/iservice/IAuthGroupService.kt
@@ -1,6 +1,8 @@
 package io.kudos.ms.auth.core.group.service.iservice
 
 import io.kudos.base.support.service.iservice.IBaseCrudService
+import io.kudos.ms.auth.common.group.vo.response.GroupDeleteImpactVo
+import io.kudos.ms.auth.common.role.vo.response.BatchBindResultVo
 import io.kudos.ms.auth.core.group.model.po.AuthGroup
 
 
@@ -13,6 +15,23 @@ import io.kudos.ms.auth.core.group.model.po.AuthGroup
  */
 interface IAuthGroupService : IBaseCrudService<String, AuthGroup> {
 
+    /**
+     * Aggregate impact summary for deleting a batch of groups: counts of distinct users and
+     * roles currently bound to any group in [groupIds]. Used by the admin UI's pre-delete
+     * confirmation so operators see the blast radius without spawning 2N GETs.
+     *
+     * Empty input yields zero counts; missing group ids contribute zero.
+     */
+    fun getDeleteImpact(groupIds: Collection<String>): GroupDeleteImpactVo
 
+    /**
+     * Batch-bind a set of users to a set of groups (Cartesian product). Per-group transaction
+     * boundary so a single failure doesn't strand the rest; partial failures are returned in
+     * [BatchBindResultVo.failures].
+     *
+     * Reuses [BatchBindResultVo] from the role package — the payload is owner-agnostic and the
+     * UI dialogue is shared between role↔user and group↔user binds.
+     */
+    fun batchBindUsers(groupIds: Collection<String>, userIds: Collection<String>): BatchBindResultVo
 
 }

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/src/io/kudos/ms/auth/core/role/service/impl/AuthRoleService.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/src/io/kudos/ms/auth/core/role/service/impl/AuthRoleService.kt
@@ -6,18 +6,27 @@ import io.kudos.base.logger.LogFactory
 import io.kudos.ms.auth.common.role.vo.AuthRoleCacheEntry
 import io.kudos.ms.auth.common.role.vo.request.AuthRoleQuery
 import io.kudos.ms.auth.common.role.vo.response.AuthRoleRow
+import io.kudos.ms.auth.common.role.vo.response.BatchBindResultVo
+import io.kudos.ms.auth.common.role.vo.response.EffectivePermissionsVo
+import io.kudos.ms.auth.common.role.vo.response.RoleDeleteImpactVo
+import io.kudos.ms.auth.core.group.cache.AuthGroupHashCache
+import io.kudos.ms.auth.core.group.service.iservice.IAuthGroupRoleService
+import io.kudos.ms.auth.core.group.service.iservice.IAuthGroupUserService
 import io.kudos.ms.auth.core.platform.cache.ResourceIdsByRoleIdCache
 import io.kudos.ms.auth.core.platform.cache.ResourceIdsByUserIdCache
 import io.kudos.ms.auth.core.role.cache.AuthRoleHashCache
 import io.kudos.ms.auth.core.role.cache.RoleIdsByUserIdCache
 import io.kudos.ms.auth.core.role.cache.UserIdsByRoleIdCache
 import io.kudos.ms.auth.core.role.dao.AuthRoleDao
+import io.kudos.ms.auth.core.role.dao.AuthRoleUserDao
 import io.kudos.ms.auth.core.role.event.AuthRoleBatchDeleted
 import io.kudos.ms.auth.core.role.event.AuthRoleDeleted
 import io.kudos.ms.auth.core.role.event.AuthRoleInserted
 import io.kudos.ms.auth.core.role.event.AuthRoleUpdated
 import io.kudos.ms.auth.core.role.model.po.AuthRole
+import io.kudos.ms.auth.core.role.service.iservice.IAuthRoleResourceService
 import io.kudos.ms.auth.core.role.service.iservice.IAuthRoleService
+import io.kudos.ms.auth.core.role.service.iservice.IAuthRoleUserService
 import io.kudos.ms.sys.common.resource.vo.SysResourceCacheEntry
 import io.kudos.ms.sys.core.resource.cache.SysResourceHashCache
 import io.kudos.ms.user.common.account.vo.UserAccountCacheEntry
@@ -25,6 +34,7 @@ import io.kudos.ms.user.core.account.cache.UserAccountHashCache
 import jakarta.annotation.Resource
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 
 
@@ -66,6 +76,31 @@ open class AuthRoleService(
 
     @Resource
     private lateinit var eventPublisher: ApplicationEventPublisher
+
+    // -- Below are injected for the aggregator methods (getEffectivePermissions, getDeleteImpact,
+    //    batchBindUsers, copyRole). They cross resource boundaries (role↔group, role↔resource) on
+    //    purpose; the alternative would be a separate "permissions facade" service, but the role
+    //    service already mixes cross-MS concerns (e.g. sysResourceHashCache) so adding these stays
+    //    in the same architectural style. None of these create a cycle: group services do not depend
+    //    on the role service.
+
+    @Resource
+    private lateinit var authRoleUserDao: AuthRoleUserDao
+
+    @Resource
+    private lateinit var authRoleUserService: IAuthRoleUserService
+
+    @Resource
+    private lateinit var authRoleResourceService: IAuthRoleResourceService
+
+    @Resource
+    private lateinit var authGroupUserService: IAuthGroupUserService
+
+    @Resource
+    private lateinit var authGroupRoleService: IAuthGroupRoleService
+
+    @Resource
+    private lateinit var authGroupHashCache: AuthGroupHashCache
 
     private val log = LogFactory.getLog(this::class)
 
@@ -231,5 +266,123 @@ open class AuthRoleService(
         return resourceIds.mapNotNull { resourcesMap[it] }
     }
 
+    // -----------------------------------------------------------------------
+    // Aggregators — replace front-end N+1 fan-outs with one-trip composite calls.
+    // -----------------------------------------------------------------------
+
+    @Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+    override fun getEffectivePermissions(userId: String): EffectivePermissionsVo {
+        // Direct role IDs: bypass IAuthRoleUserService.getRoleIdsByUserId because that's actually
+        // the cached *effective* set (it includes group-inherited roles). The dao gives the bare
+        // role_user table — which is what "direct" means.
+        val directRoleIds: List<String> = authRoleUserDao.searchRoleIdsByUserId(userId)
+        val groupIds: Set<String> = authGroupUserService.getGroupIdsByUserId(userId)
+
+        if (directRoleIds.isEmpty() && groupIds.isEmpty()) return EffectivePermissionsVo.empty()
+
+        // groupId -> role IDs inherited via that group (deduplicated by Set on the read side).
+        val roleIdsByGroup: Map<String, Set<String>> = groupIds.associateWith { gid ->
+            authGroupRoleService.getRoleIdsByGroupId(gid)
+        }
+
+        // Resolve all role metadata once (direct + inherited, dedup), then partition.
+        val allRoleIds: Set<String> = (directRoleIds.asSequence() + roleIdsByGroup.values.asSequence().flatten()).toSet()
+        val rolesMap: Map<String, AuthRoleCacheEntry> =
+            if (allRoleIds.isEmpty()) emptyMap() else authRoleHashCache.getRolesByIds(allRoleIds)
+
+        val directRoles: List<AuthRoleCacheEntry> = directRoleIds.mapNotNull { rolesMap[it] }
+        val groupsList: List<AuthGroupCacheEntryAlias> =
+            if (groupIds.isEmpty()) emptyList() else authGroupHashCache.getGroupsByIds(groupIds).values.toList()
+        val rolesByGroup: Map<String, List<AuthRoleCacheEntry>> =
+            roleIdsByGroup.mapValues { (_, rids) -> rids.mapNotNull { rolesMap[it] } }
+
+        // Resources per role: one cache hit per role for the id list, one batch lookup for metadata.
+        // Empty roles are pruned so the JSON doesn't carry useless `roleId: []` pairs.
+        val resourcesByRole: Map<String, List<SysResourceCacheEntry>> = allRoleIds.associateWith { rid ->
+            val resIds = resourceIdsByRoleIdCache.getResourceIds(rid)
+            if (resIds.isEmpty()) emptyList() else {
+                val map = sysResourceHashCache.getResourcesByIds(resIds.toSet())
+                resIds.mapNotNull { map[it] }
+            }
+        }.filterValues { it.isNotEmpty() }
+
+        return EffectivePermissionsVo(
+            directRoles = directRoles,
+            groups = groupsList,
+            rolesByGroup = rolesByGroup,
+            resourcesByRole = resourcesByRole,
+        )
+    }
+
+    @Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+    override fun getDeleteImpact(roleIds: Collection<String>): RoleDeleteImpactVo {
+        if (roleIds.isEmpty()) return RoleDeleteImpactVo.zero()
+        // Union over all roles. Sets de-duplicate so a user/group bound to multiple roles in the
+        // batch counts once — matches the UI's "this batch's blast radius" phrasing.
+        val allUserIds = HashSet<String>()
+        val allGroupIds = HashSet<String>()
+        for (rid in roleIds) {
+            allUserIds.addAll(authRoleUserService.getUserIdsByRoleId(rid))
+            allGroupIds.addAll(authGroupRoleService.getGroupIdsByRoleId(rid))
+        }
+        return RoleDeleteImpactVo(users = allUserIds.size, groups = allGroupIds.size)
+    }
+
+    @Transactional
+    override fun batchBindUsers(roleIds: Collection<String>, userIds: Collection<String>): BatchBindResultVo {
+        if (roleIds.isEmpty() || userIds.isEmpty()) return BatchBindResultVo.empty()
+        var ok = 0
+        val failures = mutableListOf<BatchBindResultVo.BatchBindFailure>()
+        // Per-role transaction boundary: each batchBind is its own commit so a bad row doesn't
+        // strand the rest. The admin UI displays partial-failure detail; cross-role atomicity
+        // isn't worth the multi-row write lock.
+        for (rid in roleIds) {
+            try {
+                authRoleUserService.batchBind(rid, userIds)
+                ok++
+            } catch (e: Exception) {
+                log.warn("Batch-bind failed for role ${rid}: ${e.message}")
+                failures += BatchBindResultVo.BatchBindFailure(ownerId = rid, reason = e.message ?: e.javaClass.simpleName)
+            }
+        }
+        return BatchBindResultVo(ok = ok, failures = failures)
+    }
+
+    @Transactional
+    override fun copyRole(sourceId: String, code: String, name: String, copyResources: Boolean): String {
+        require(code.isNotBlank()) { "Target role code must not be blank" }
+        require(name.isNotBlank()) { "Target role name must not be blank" }
+        val source = authRoleHashCache.getRoleById(sourceId)
+            ?: throw IllegalArgumentException("Source role not found: $sourceId")
+
+        // Build the new PO from the source's audit-neutral fields. Audit columns (createUserId
+        // etc.) are left null so BaseCrudService's audit interceptor stamps the current operator.
+        val newRole = AuthRole.Companion {
+            this.code = code
+            this.name = name
+            // Required non-null fields on the PO; the cache entry's tenantId / subsysCode are
+            // nullable so we fall back to empty-string when (somehow) absent rather than NPE.
+            this.tenantId = source.tenantId ?: ""
+            this.subsysCode = source.subsysCode ?: ""
+            this.remark = source.remark
+            this.active = source.active ?: true
+            this.builtIn = false  // copies are never built-in regardless of source
+        }
+        val newId: String = dao.insert(newRole)
+        log.debug("Copied role ${sourceId} -> ${newId} (copyResources=${copyResources})")
+        eventPublisher.publishEvent(AuthRoleInserted(newId))
+
+        if (copyResources) {
+            val resourceIds = authRoleResourceService.getResourceIdsByRoleId(sourceId)
+            if (resourceIds.isNotEmpty()) {
+                authRoleResourceService.batchBind(newId, resourceIds)
+                log.debug("Copied ${resourceIds.size} resource grants from role ${sourceId} to ${newId}.")
+            }
+        }
+        return newId
+    }
 
 }
+
+/** Local alias so the type appears in the import block above for clarity. */
+private typealias AuthGroupCacheEntryAlias = io.kudos.ms.auth.common.group.vo.AuthGroupCacheEntry

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/src/io/kudos/ms/auth/core/role/service/iservice/IAuthRoleService.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/src/io/kudos/ms/auth/core/role/service/iservice/IAuthRoleService.kt
@@ -3,6 +3,9 @@ package io.kudos.ms.auth.core.role.service.iservice
 import io.kudos.base.support.service.iservice.IBaseCrudService
 import io.kudos.ms.auth.common.role.vo.AuthRoleCacheEntry
 import io.kudos.ms.auth.common.role.vo.response.AuthRoleRow
+import io.kudos.ms.auth.common.role.vo.response.BatchBindResultVo
+import io.kudos.ms.auth.common.role.vo.response.EffectivePermissionsVo
+import io.kudos.ms.auth.common.role.vo.response.RoleDeleteImpactVo
 import io.kudos.ms.auth.core.role.model.po.AuthRole
 import io.kudos.ms.sys.common.resource.vo.SysResourceCacheEntry
 import io.kudos.ms.user.common.account.vo.UserAccountCacheEntry
@@ -192,6 +195,50 @@ interface IAuthRoleService : IBaseCrudService<String, AuthRole> {
      * @return List<SysResourceCacheEntry> List of resource cache objects; returns empty list if user does not exist or has no resources
      */
     fun getResources(userId: String): List<SysResourceCacheEntry>
+
+    /**
+     * One-shot snapshot of a user's effective permissions: direct roles + group memberships +
+     * group-inherited roles + resources per role. Replaces a fan-out of 1 + 1 + N + M + 3 calls
+     * from the console UI with a single round-trip.
+     *
+     * Returns [EffectivePermissionsVo.empty] when the user has neither direct nor inherited
+     * grants — never throws for missing users; the contract is "what does this user effectively
+     * have", not "does this user exist".
+     *
+     * @param userId User id to inspect.
+     */
+    fun getEffectivePermissions(userId: String): EffectivePermissionsVo
+
+    /**
+     * Aggregate impact summary for deleting a batch of roles: counts of distinct users and
+     * groups currently bound to any role in [roleIds]. Used by the admin UI's pre-delete
+     * confirmation so operators see the blast radius without spawning 2N GETs.
+     *
+     * Empty input yields zero counts; missing role ids contribute zero (the contract is
+     * "how many bindings would be removed if I deleted these", not "are these ids real").
+     */
+    fun getDeleteImpact(roleIds: Collection<String>): RoleDeleteImpactVo
+
+    /**
+     * Batch-bind a set of users to a set of roles (Cartesian product). For each role, calls
+     * the existing batch-bind path; partial failure is captured per-role and returned in
+     * [BatchBindResultVo.failures] so the admin UI can show "succeeded for 3 of 5 roles" with
+     * actionable per-role error messages.
+     *
+     * Atomicity scope: each role's bind is its own transaction; cross-role atomicity would
+     * require holding a multi-row write lock, which isn't worth it for an admin-side bulk action.
+     */
+    fun batchBindUsers(roleIds: Collection<String>, userIds: Collection<String>): BatchBindResultVo
+
+    /**
+     * Atomic role-copy: read source role's detail, save a new role with the supplied [code] and
+     * [name] (other fields inherited from the source), optionally copy the source's resource
+     * grants in the same transaction.
+     *
+     * Returns the new role id. Throws if the source doesn't exist or the new code/name collides
+     * with an existing role under the same tenant + subsystem.
+     */
+    fun copyRole(sourceId: String, code: String, name: String, copyResources: Boolean): String
 
 
 }


### PR DESCRIPTION
Console UI's role/group/effective-permissions pages were spawning N+M+K HTTP calls for what is logically one read or one write. This change adds the backing service+controller endpoints so those flows can become single-round-trip.

New endpoints (admin layer):

- GET  /api/admin/auth/role/getEffectivePermissions?userId=... EffectivePermissionsVo = direct roles + groups + group-inherited roles + resources-per-role. Replaces 1+1+N+M+3 calls in AccountEffectivePermissionsDialog.
- POST /api/admin/auth/role/getDeleteImpact     body=[roleIds]
    RoleDeleteImpactVo = distinct counts of bound users + groups. Replaces 2N
    calls before the role list page's pre-delete confirm.
- POST /api/admin/auth/group/getDeleteImpact    body=[groupIds]
    GroupDeleteImpactVo = distinct counts of bound users + roles.
- POST /api/admin/auth/role/batchBindUsers      body={roleIds, userIds}
    BatchBindResultVo = {ok, failures[]}. Cartesian-product bind; per-role
    transactional boundary so a single bad row doesn't strand the rest.
- POST /api/admin/auth/group/batchBindUsers     body={groupIds, userIds}
    Symmetric for groups.
- POST /api/admin/auth/role/copyRole            body={sourceId, code, name, copyResources}
    Atomic role-copy in one transaction: insert new role from source's fields
    (overriding code/name), optionally bind the source's resource grants.

Service layer (kudos-ms-auth-core):

- IAuthRoleService.getEffectivePermissions / getDeleteImpact / batchBindUsers / copyRole — implementations in AuthRoleService inject AuthRoleUserDao, IAuthRoleUserService, IAuthRoleResourceService, IAuthGroupUserService, IAuthGroupRoleService, AuthGroupHashCache. No new circular deps (the group services don't reach back to role).
- IAuthGroupService.getDeleteImpact / batchBindUsers — same pattern using IAuthGroupUserService + IAuthGroupRoleService.

VOs (kudos-ms-auth-common):

- response: EffectivePermissionsVo, RoleDeleteImpactVo, GroupDeleteImpactVo, BatchBindResultVo (with nested BatchBindFailure; reused by both role and group batch-bind responses)
- request: AuthRoleBatchBindUsersRequest, AuthGroupBatchBindUsersRequest, AuthRoleCopyRequest

Notes:

- Direct-vs-inherited role distinction: bypass IAuthRoleUserService.getRoleIdsByUserId for direct IDs because that path returns the *effective* set (it goes through RoleIdsByUserIdCache which merges direct + group-inherited). The dao call AuthRoleUserDao.searchRoleIdsByUserId is the bare role_user table.
- Per-row transactional boundary in batchBindUsers is deliberate: cross-owner atomicity would require a multi-row write lock, and the admin UI prefers partial-success reporting over blanket rollback.
- builtIn = false on copied roles regardless of source's value — copies are never themselves built-in.
- Existing auth-core tests fail on this branch and on main with the same "sys_cache table not found" infra error (unrelated to these changes).