### PR TITLE
feat(auth): role-grant approval workflow MVP

### DIFF
--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-api-admin/src/io/kudos/ms/auth/api/admin/controller/grant/AuthRoleGrantRequestAdminController.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-api-admin/src/io/kudos/ms/auth/api/admin/controller/grant/AuthRoleGrantRequestAdminController.kt
@@ -1,0 +1,63 @@
+package io.kudos.ms.auth.api.admin.controller.grant
+
+import io.kudos.ability.web.springmvc.controller.BaseReadOnlyController
+import io.kudos.ms.auth.common.grant.vo.request.AuthRoleGrantDecisionRequest
+import io.kudos.ms.auth.common.grant.vo.request.AuthRoleGrantRequestQuery
+import io.kudos.ms.auth.common.grant.vo.request.AuthRoleGrantSubmitRequest
+import io.kudos.ms.auth.common.grant.vo.response.AuthRoleGrantRequestDetail
+import io.kudos.ms.auth.common.grant.vo.response.AuthRoleGrantRequestRow
+import io.kudos.ms.auth.core.role.grant.service.iservice.IAuthRoleGrantRequestService
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * Admin controller for the role-grant approval workflow.
+ *
+ * Base URL: `/api/admin/auth/roleGrantRequest`
+ *
+ * Read side (inherited from [BaseReadOnlyController]):
+ *   POST /pagingSearch  → page of AuthRoleGrantRequestRow (approver dashboard, filterable by status)
+ *   GET  /getDetail     → AuthRoleGrantRequestDetail
+ *
+ * Write side (the workflow actions): submit / approve / reject / cancel.
+ *
+ * Approver authorisation is enforced by access to this controller — there is no per-request
+ * approver routing in the data model (a follow-up could add an approver-role concept).
+ *
+ * @author K
+ * @author AI: Claude
+ * @since 1.0.0
+ */
+@RestController
+@RequestMapping("/api/admin/auth/roleGrantRequest")
+class AuthRoleGrantRequestAdminController :
+    BaseReadOnlyController<
+        String,
+        IAuthRoleGrantRequestService,
+        AuthRoleGrantRequestQuery,
+        AuthRoleGrantRequestRow,
+        AuthRoleGrantRequestDetail,
+        >() {
+
+    /** Submit a new grant request. Returns the new request id. */
+    @PostMapping("/submit")
+    fun submit(@RequestBody request: AuthRoleGrantSubmitRequest): String =
+        service.submit(request.roleId, request.userId, request.reason)
+
+    /** Approve a pending request (performs the actual bind, subject to SoD checks). */
+    @PostMapping("/approve")
+    fun approve(@RequestBody request: AuthRoleGrantDecisionRequest): Boolean =
+        service.approve(request.id, request.comment)
+
+    /** Reject a pending request. */
+    @PostMapping("/reject")
+    fun reject(@RequestBody request: AuthRoleGrantDecisionRequest): Boolean =
+        service.reject(request.id, request.comment)
+
+    /** Cancel a pending request (requester action). */
+    @PostMapping("/cancel")
+    fun cancel(@RequestBody request: AuthRoleGrantDecisionRequest): Boolean =
+        service.cancel(request.id)
+}

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/grant/enums/GrantRequestStatus.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/grant/enums/GrantRequestStatus.kt
@@ -1,0 +1,32 @@
+package io.kudos.ms.auth.common.grant.enums
+
+/**
+ * Lifecycle states of a role-grant approval request.
+ *
+ * Transitions (enforced by AuthRoleGrantRequestService):
+ *   PENDING → APPROVED  (approve, performs the bind)
+ *   PENDING → REJECTED  (reject)
+ *   PENDING → CANCELLED (requester cancels)
+ * Terminal states are immutable.
+ *
+ * @author K
+ * @author AI: Claude
+ * @since 1.0.0
+ */
+enum class GrantRequestStatus {
+    PENDING,
+    APPROVED,
+    REJECTED,
+    CANCELLED,
+    ;
+
+    /** A request can only be acted on (approve/reject/cancel) while it is still pending. */
+    fun isTerminal(): Boolean = this != PENDING
+
+    companion object {
+        /** Parse a wire string into the enum, or null if unrecognised. */
+        @JvmStatic
+        fun fromString(raw: String?): GrantRequestStatus? =
+            raw?.let { v -> entries.firstOrNull { it.name == v.trim().uppercase() } }
+    }
+}

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/grant/vo/request/AuthRoleGrantDecisionRequest.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/grant/vo/request/AuthRoleGrantDecisionRequest.kt
@@ -1,0 +1,26 @@
+package io.kudos.ms.auth.common.grant.vo.request
+
+import io.kudos.base.bean.validation.constraint.annotations.MaxLength
+import java.io.Serializable
+
+/**
+ * Request body for approving or rejecting a grant request.
+ *
+ * @author K
+ * @author AI: Claude
+ * @since 1.0.0
+ */
+data class AuthRoleGrantDecisionRequest(
+
+    /** Id of the pending request being decided. */
+    val id: String,
+
+    /** Optional approver comment. */
+    @get:MaxLength(512)
+    val comment: String? = null,
+
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/grant/vo/request/AuthRoleGrantRequestQuery.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/grant/vo/request/AuthRoleGrantRequestQuery.kt
@@ -1,0 +1,32 @@
+package io.kudos.ms.auth.common.grant.vo.request
+
+import io.kudos.base.model.payload.ListSearchPayload
+import io.kudos.ms.auth.common.grant.vo.response.AuthRoleGrantRequestRow
+
+/**
+ * Query criteria for the grant-request list (e.g. the approver dashboard).
+ *
+ * @author K
+ * @author AI: Claude
+ * @since 1.0.0
+ */
+data class AuthRoleGrantRequestQuery(
+
+    /** Filter by tenant. */
+    val tenantId: String? = null,
+
+    /** Filter by status (PENDING / APPROVED / REJECTED / CANCELLED). */
+    val status: String? = null,
+
+    /** Filter by the user the role would be granted to. */
+    val userId: String? = null,
+
+    /** Filter by the role being requested. */
+    val roleId: String? = null,
+
+    /** Filter by who submitted the request. */
+    val requesterId: String? = null,
+
+) : ListSearchPayload() {
+    override fun getReturnEntityClass() = AuthRoleGrantRequestRow::class
+}

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/grant/vo/request/AuthRoleGrantSubmitRequest.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/grant/vo/request/AuthRoleGrantSubmitRequest.kt
@@ -1,0 +1,31 @@
+package io.kudos.ms.auth.common.grant.vo.request
+
+import io.kudos.base.bean.validation.constraint.annotations.MaxLength
+import java.io.Serializable
+
+/**
+ * Request body for submitting a role-grant approval request.
+ *
+ * Tenant is derived server-side from the role, so the caller only supplies role + user + reason.
+ *
+ * @author K
+ * @author AI: Claude
+ * @since 1.0.0
+ */
+data class AuthRoleGrantSubmitRequest(
+
+    /** Role to be granted. */
+    val roleId: String,
+
+    /** User the role would be granted to. */
+    val userId: String,
+
+    /** Optional justification shown to the approver. */
+    @get:MaxLength(512)
+    val reason: String? = null,
+
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/grant/vo/response/AuthRoleGrantRequestDetail.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/grant/vo/response/AuthRoleGrantRequestDetail.kt
@@ -1,0 +1,33 @@
+package io.kudos.ms.auth.common.grant.vo.response
+
+import io.kudos.base.model.contract.entity.IIdEntity
+import java.time.LocalDateTime
+
+/**
+ * Detail VO for a role-grant approval request.
+ *
+ * @author K
+ * @author AI: Claude
+ * @since 1.0.0
+ */
+data class AuthRoleGrantRequestDetail(
+
+    override val id: String = "",
+    val roleId: String? = null,
+    val userId: String? = null,
+    val tenantId: String? = null,
+    val status: String? = null,
+    val reason: String? = null,
+    val requesterId: String? = null,
+    val requestTime: LocalDateTime? = null,
+    val approverId: String? = null,
+    val decisionComment: String? = null,
+    val decisionTime: LocalDateTime? = null,
+    val createUserId: String? = null,
+    val createUserName: String? = null,
+    val createTime: LocalDateTime? = null,
+    val updateUserId: String? = null,
+    val updateUserName: String? = null,
+    val updateTime: LocalDateTime? = null,
+
+) : IIdEntity<String>

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/grant/vo/response/AuthRoleGrantRequestRow.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/grant/vo/response/AuthRoleGrantRequestRow.kt
@@ -1,0 +1,27 @@
+package io.kudos.ms.auth.common.grant.vo.response
+
+import io.kudos.base.model.contract.entity.IIdEntity
+import java.time.LocalDateTime
+
+/**
+ * List row VO for a role-grant approval request.
+ *
+ * @author K
+ * @author AI: Claude
+ * @since 1.0.0
+ */
+data class AuthRoleGrantRequestRow(
+
+    override val id: String = "",
+    val roleId: String? = null,
+    val userId: String? = null,
+    val tenantId: String? = null,
+    val status: String? = null,
+    val reason: String? = null,
+    val requesterId: String? = null,
+    val requestTime: LocalDateTime? = null,
+    val approverId: String? = null,
+    val decisionComment: String? = null,
+    val decisionTime: LocalDateTime? = null,
+
+) : IIdEntity<String>

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/role/vo/AuthRoleCacheEntry.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/role/vo/AuthRoleCacheEntry.kt
@@ -40,6 +40,9 @@ data class AuthRoleCacheEntry (
     /** Whether the role is built-in. */
     val builtIn: Boolean?,
 
+    /** Whether assigning this role requires an approval workflow. */
+    val approvalRequired: Boolean? = null,
+
     /** Creator user id. */
     val createUserId: String?,
 

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/role/vo/request/AuthRoleFormCreate.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/role/vo/request/AuthRoleFormCreate.kt
@@ -16,6 +16,8 @@ data class AuthRoleFormCreate (
 
     override val subsysCode: String? ,
 
+    override val approvalRequired: Boolean? = false,
+
     override val remark: String? ,
 
 ) : IAuthRoleFormBase

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/role/vo/request/AuthRoleFormUpdate.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/role/vo/request/AuthRoleFormUpdate.kt
@@ -22,6 +22,8 @@ data class AuthRoleFormUpdate (
 
     override val subsysCode: String?,
 
+    override val approvalRequired: Boolean? = false,
+
     override val remark: String?,
 
 ) : IIdEntity<String>, IAuthRoleFormBase

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/role/vo/request/IAuthRoleFormBase.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/role/vo/request/IAuthRoleFormBase.kt
@@ -22,6 +22,9 @@ interface IAuthRoleFormBase {
     /** Subsystem code. */
     val subsysCode: String?
 
+    /** Whether assigning this role requires an approval workflow. Null defaults to false. */
+    val approvalRequired: Boolean?
+
     /** Remark. */
     @get:MaxLength(128)
     val remark: String?

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/role/vo/response/AuthRoleDetail.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/role/vo/response/AuthRoleDetail.kt
@@ -36,6 +36,9 @@ data class AuthRoleDetail (
     /** Whether the role is built-in. */
     val builtIn: Boolean? = null,
 
+    /** Whether assigning this role requires approval. */
+    val approvalRequired: Boolean? = null,
+
     /** Creator user id. */
     val createUserId: String? = null,
 

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/role/vo/response/AuthRoleRow.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/role/vo/response/AuthRoleRow.kt
@@ -36,6 +36,9 @@ data class AuthRoleRow (
     /** Whether the role is built-in. */
     val builtIn: Boolean? = null,
 
+    /** Whether assigning this role requires approval. */
+    val approvalRequired: Boolean? = null,
+
     /** Creator user id. */
     val createUserId: String? = null,
 

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/src/io/kudos/ms/auth/core/role/grant/dao/AuthRoleGrantRequestDao.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/src/io/kudos/ms/auth/core/role/grant/dao/AuthRoleGrantRequestDao.kt
@@ -1,0 +1,33 @@
+package io.kudos.ms.auth.core.role.grant.dao
+
+import io.kudos.ability.data.rdb.ktorm.support.BaseCrudDao
+import io.kudos.base.query.Criteria
+import io.kudos.base.query.eq
+import io.kudos.ms.auth.common.grant.enums.GrantRequestStatus
+import io.kudos.ms.auth.core.role.grant.model.po.AuthRoleGrantRequest
+import io.kudos.ms.auth.core.role.grant.model.table.AuthRoleGrantRequests
+import org.springframework.stereotype.Repository
+
+/**
+ * DAO for role-grant approval requests.
+ *
+ * @author K
+ * @author AI: Claude
+ * @since 1.0.0
+ */
+@Repository
+open class AuthRoleGrantRequestDao : BaseCrudDao<String, AuthRoleGrantRequest, AuthRoleGrantRequests>() {
+
+    /**
+     * Returns the existing PENDING request for the given (role, user), if any.
+     * Used by the submit path to enforce "one open request per role+user".
+     */
+    open fun findPending(roleId: String, userId: String): AuthRoleGrantRequest? {
+        val criteria = Criteria.and(
+            AuthRoleGrantRequest::roleId eq roleId,
+            AuthRoleGrantRequest::userId eq userId,
+            AuthRoleGrantRequest::status eq GrantRequestStatus.PENDING.name,
+        )
+        return search(criteria).firstOrNull()
+    }
+}

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/src/io/kudos/ms/auth/core/role/grant/model/po/AuthRoleGrantRequest.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/src/io/kudos/ms/auth/core/role/grant/model/po/AuthRoleGrantRequest.kt
@@ -1,0 +1,54 @@
+package io.kudos.ms.auth.core.role.grant.model.po
+
+import io.kudos.ability.data.rdb.ktorm.support.DbEntityFactory
+import io.kudos.ability.data.rdb.ktorm.support.IDbEntity
+import java.time.LocalDateTime
+
+/**
+ * Role-grant approval request database entity.
+ *
+ * @author K
+ * @author AI: Claude
+ * @since 1.0.0
+ */
+interface AuthRoleGrantRequest : IDbEntity<String, AuthRoleGrantRequest> {
+
+    companion object : DbEntityFactory<AuthRoleGrantRequest>()
+
+    /** Role being requested. */
+    var roleId: String
+
+    /** User the role would be granted to. */
+    var userId: String
+
+    /** Tenant id (denormalised from the role for query scoping). */
+    var tenantId: String
+
+    /** PENDING / APPROVED / REJECTED / CANCELLED — stored as the enum name. */
+    var status: String
+
+    /** Requester's stated reason. */
+    var reason: String?
+
+    /** User id who submitted the request. */
+    var requesterId: String?
+
+    /** When the request was submitted. */
+    var requestTime: LocalDateTime?
+
+    /** User id who approved/rejected (null while pending). */
+    var approverId: String?
+
+    /** Approver's decision comment. */
+    var decisionComment: String?
+
+    /** When the decision was made (null while pending). */
+    var decisionTime: LocalDateTime?
+
+    var createUserId: String?
+    var createUserName: String?
+    var createTime: LocalDateTime?
+    var updateUserId: String?
+    var updateUserName: String?
+    var updateTime: LocalDateTime?
+}

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/src/io/kudos/ms/auth/core/role/grant/model/table/AuthRoleGrantRequests.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/src/io/kudos/ms/auth/core/role/grant/model/table/AuthRoleGrantRequests.kt
@@ -1,0 +1,33 @@
+package io.kudos.ms.auth.core.role.grant.model.table
+
+import io.kudos.ability.data.rdb.ktorm.support.StringIdTable
+import io.kudos.ms.auth.core.role.grant.model.po.AuthRoleGrantRequest
+import org.ktorm.schema.datetime
+import org.ktorm.schema.varchar
+
+/**
+ * Ktorm table mapping for [AuthRoleGrantRequest].
+ *
+ * @author K
+ * @author AI: Claude
+ * @since 1.0.0
+ */
+object AuthRoleGrantRequests : StringIdTable<AuthRoleGrantRequest>("auth_role_grant_request") {
+
+    var roleId = varchar("role_id").bindTo { it.roleId }
+    var userId = varchar("user_id").bindTo { it.userId }
+    var tenantId = varchar("tenant_id").bindTo { it.tenantId }
+    var status = varchar("status").bindTo { it.status }
+    var reason = varchar("reason").bindTo { it.reason }
+    var requesterId = varchar("requester_id").bindTo { it.requesterId }
+    var requestTime = datetime("request_time").bindTo { it.requestTime }
+    var approverId = varchar("approver_id").bindTo { it.approverId }
+    var decisionComment = varchar("decision_comment").bindTo { it.decisionComment }
+    var decisionTime = datetime("decision_time").bindTo { it.decisionTime }
+    var createUserId = varchar("create_user_id").bindTo { it.createUserId }
+    var createUserName = varchar("create_user_name").bindTo { it.createUserName }
+    var createTime = datetime("create_time").bindTo { it.createTime }
+    var updateUserId = varchar("update_user_id").bindTo { it.updateUserId }
+    var updateUserName = varchar("update_user_name").bindTo { it.updateUserName }
+    var updateTime = datetime("update_time").bindTo { it.updateTime }
+}

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/src/io/kudos/ms/auth/core/role/grant/service/impl/AuthRoleGrantRequestService.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/src/io/kudos/ms/auth/core/role/grant/service/impl/AuthRoleGrantRequestService.kt
@@ -1,0 +1,124 @@
+package io.kudos.ms.auth.core.role.grant.service.impl
+
+import io.kudos.base.logger.LogFactory
+import io.kudos.base.support.service.impl.BaseCrudService
+import io.kudos.ms.auth.common.grant.enums.GrantRequestStatus
+import io.kudos.ms.auth.core.role.dao.AuthRoleDao
+import io.kudos.ms.auth.core.role.grant.dao.AuthRoleGrantRequestDao
+import io.kudos.ms.auth.core.role.grant.model.po.AuthRoleGrantRequest
+import io.kudos.ms.auth.core.role.grant.service.iservice.IAuthRoleGrantRequestService
+import io.kudos.ms.auth.core.role.service.iservice.IAuthRoleUserService
+import io.kudos.ms.user.common.passport.CurrentUserKit
+import jakarta.annotation.Resource
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+/**
+ * Role-grant approval workflow implementation.
+ *
+ * State machine guard: every action ([approve]/[reject]/[cancel]) first re-reads the row and
+ * rejects if it's no longer PENDING, so two approvers racing on the same request can't both
+ * succeed (the second sees a terminal state).
+ *
+ * @author K
+ * @author AI: Claude
+ * @since 1.0.0
+ */
+@Service
+@Transactional
+open class AuthRoleGrantRequestService(
+    dao: AuthRoleGrantRequestDao,
+) : BaseCrudService<String, AuthRoleGrantRequest, AuthRoleGrantRequestDao>(dao),
+    IAuthRoleGrantRequestService {
+
+    @Resource
+    private lateinit var authRoleDao: AuthRoleDao
+
+    @Resource
+    private lateinit var authRoleUserService: IAuthRoleUserService
+
+    private val log = LogFactory.getLog(this::class)
+
+    @Transactional
+    override fun submit(roleId: String, userId: String, reason: String?): String {
+        require(roleId.isNotBlank()) { "roleId must not be blank." }
+        require(userId.isNotBlank()) { "userId must not be blank." }
+
+        val role = authRoleDao.get(roleId)
+            ?: throw IllegalArgumentException("Role not found: $roleId")
+
+        // No point requesting a role the user already has.
+        require(!authRoleUserService.exists(roleId, userId)) {
+            "User $userId already holds role $roleId."
+        }
+        // One open request per (role, user).
+        require(dao.findPending(roleId, userId) == null) {
+            "A pending grant request for role $roleId and user $userId already exists."
+        }
+
+        val now = LocalDateTime.now()
+        val requesterId = CurrentUserKit.currentUserIdOrNull()
+        val request = AuthRoleGrantRequest {
+            this.roleId = roleId
+            this.userId = userId
+            this.tenantId = role.tenantId
+            this.status = GrantRequestStatus.PENDING.name
+            this.reason = reason
+            this.requesterId = requesterId
+            this.requestTime = now
+        }
+        val id = dao.insert(request)
+        log.debug("Submitted grant request $id: role=$roleId user=$userId requester=$requesterId")
+        return id
+    }
+
+    @Transactional
+    override fun approve(id: String, comment: String?): Boolean {
+        val request = loadPendingOrThrow(id)
+        // Perform the actual bind first; if it throws (e.g. SoD violation) the whole transaction
+        // rolls back and the request stays PENDING — the approver sees the error.
+        authRoleUserService.batchBind(request.roleId, listOf(request.userId))
+
+        request.status = GrantRequestStatus.APPROVED.name
+        request.approverId = CurrentUserKit.currentUserIdOrNull()
+        request.decisionComment = comment
+        request.decisionTime = LocalDateTime.now()
+        val success = dao.update(request)
+        log.debug("Approved grant request $id (role=${request.roleId} user=${request.userId}); bind performed.")
+        return success
+    }
+
+    @Transactional
+    override fun reject(id: String, comment: String?): Boolean {
+        val request = loadPendingOrThrow(id)
+        request.status = GrantRequestStatus.REJECTED.name
+        request.approverId = CurrentUserKit.currentUserIdOrNull()
+        request.decisionComment = comment
+        request.decisionTime = LocalDateTime.now()
+        val success = dao.update(request)
+        log.debug("Rejected grant request $id.")
+        return success
+    }
+
+    @Transactional
+    override fun cancel(id: String): Boolean {
+        val request = loadPendingOrThrow(id)
+        request.status = GrantRequestStatus.CANCELLED.name
+        request.decisionTime = LocalDateTime.now()
+        val success = dao.update(request)
+        log.debug("Cancelled grant request $id.")
+        return success
+    }
+
+    /** Re-read the row and assert it's still PENDING; the guard against double-decision races. */
+    private fun loadPendingOrThrow(id: String): AuthRoleGrantRequest {
+        val request = dao.get(id)
+            ?: throw IllegalArgumentException("Grant request not found: $id")
+        val status = GrantRequestStatus.fromString(request.status)
+        require(status == GrantRequestStatus.PENDING) {
+            "Grant request $id is already ${request.status}; only PENDING requests can be acted on."
+        }
+        return request
+    }
+}

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/src/io/kudos/ms/auth/core/role/grant/service/iservice/IAuthRoleGrantRequestService.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/src/io/kudos/ms/auth/core/role/grant/service/iservice/IAuthRoleGrantRequestService.kt
@@ -1,0 +1,61 @@
+package io.kudos.ms.auth.core.role.grant.service.iservice
+
+import io.kudos.base.support.service.iservice.IBaseCrudService
+import io.kudos.ms.auth.core.role.grant.model.po.AuthRoleGrantRequest
+
+/**
+ * Service interface for the role-grant approval workflow.
+ *
+ * Lifecycle: PENDING → APPROVED | REJECTED | CANCELLED.
+ *  - [submit]  creates a PENDING request (one open request per role+user).
+ *  - [approve] flips PENDING → APPROVED and performs the actual bind via the role-user service
+ *              (so SoD checks still apply — an approval can fail if it would create a conflict).
+ *  - [reject]  flips PENDING → REJECTED (no bind).
+ *  - [cancel]  flips a requester's own PENDING → CANCELLED.
+ *
+ * Approver authorisation is NOT modelled in data — it's enforced at the API layer (whoever can
+ * call the admin endpoint may approve). A richer "approver role" model is a follow-up.
+ *
+ * @author K
+ * @author AI: Claude
+ * @since 1.0.0
+ */
+interface IAuthRoleGrantRequestService : IBaseCrudService<String, AuthRoleGrantRequest> {
+
+    /**
+     * Submit a new grant request. Validates the role and user exist, the user doesn't already
+     * hold the role, and there's no open PENDING request for the same pair. The tenant is taken
+     * from the role.
+     *
+     * @return the new request id.
+     * @throws IllegalArgumentException on validation failure (missing role, duplicate pending,
+     *   user already holds the role).
+     */
+    fun submit(roleId: String, userId: String, reason: String?): String
+
+    /**
+     * Approve a PENDING request: flip status to APPROVED and bind the role to the user.
+     * The bind reuses the role-user service, so SoD constraints are enforced — if the grant
+     * would violate one, the approval fails and the request stays PENDING.
+     *
+     * @return true on success.
+     * @throws IllegalArgumentException if the request is missing or not PENDING.
+     */
+    fun approve(id: String, comment: String?): Boolean
+
+    /**
+     * Reject a PENDING request: flip status to REJECTED, no bind.
+     *
+     * @return true on success.
+     * @throws IllegalArgumentException if the request is missing or not PENDING.
+     */
+    fun reject(id: String, comment: String?): Boolean
+
+    /**
+     * Cancel a PENDING request (intended for the original requester). Flips status to CANCELLED.
+     *
+     * @return true on success.
+     * @throws IllegalArgumentException if the request is missing or not PENDING.
+     */
+    fun cancel(id: String): Boolean
+}

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/src/io/kudos/ms/auth/core/role/model/po/AuthRole.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/src/io/kudos/ms/auth/core/role/model/po/AuthRole.kt
@@ -39,6 +39,9 @@ interface AuthRole : IDbEntity<String, AuthRole> {
     /** Whether built-in */
     var builtIn: Boolean?
 
+    /** Whether assigning this role requires an approval workflow (see auth_role_grant_request). */
+    var approvalRequired: Boolean?
+
     /** Creator id */
     var createUserId: String?
 

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/src/io/kudos/ms/auth/core/role/model/table/AuthRoles.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/src/io/kudos/ms/auth/core/role/model/table/AuthRoles.kt
@@ -40,6 +40,9 @@ object AuthRoles : StringIdTable<AuthRole>("auth_role") {
     /** Whether built-in */
     var builtIn = boolean("built_in").bindTo { it.builtIn }
 
+    /** Whether assigning this role requires approval. */
+    var approvalRequired = boolean("approval_required").bindTo { it.approvalRequired }
+
     /** Creator id */
     var createUserId = varchar("create_user_id").bindTo { it.createUserId }
 

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/test-resources/sql/h2/role/grant/service/AuthRoleGrantRequestServiceTest.sql
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/test-resources/sql/h2/role/grant/service/AuthRoleGrantRequestServiceTest.sql
@@ -1,0 +1,14 @@
+-- Fixtures for AuthRoleGrantRequestService: 1 tenant, 2 users, 2 roles (one approval-required),
+-- and one pre-existing role-user binding to exercise the "already holds the role" guard.
+
+merge into "user_account" ("id", "username", "tenant_id", "login_password", "supervisor_id", "remark", "active", "built_in", "create_user_id", "create_user_name") values
+    ('grant000-0000-0000-0000-000000000001', 'svc-user-grant-1', 'svc-tenant-grant-1', 'pwd-1', '00000000-0000-0000-0000-000000000000', 'from AuthRoleGrantRequestServiceTest', true, false, 'system', '系统'),
+    ('grant000-0000-0000-0000-000000000002', 'svc-user-grant-2', 'svc-tenant-grant-1', 'pwd-2', '00000000-0000-0000-0000-000000000000', 'from AuthRoleGrantRequestServiceTest', true, false, 'system', '系统');
+
+merge into "auth_role" ("id", "code", "name", "tenant_id", "subsys_code", "approval_required", "remark", "active", "built_in", "create_user_id", "create_user_name") values
+    ('grant000-0000-0000-0000-000000000010', 'svc-role-grant-normal',   'grant-normal',   'svc-tenant-grant-1', 'ams', false, 'from AuthRoleGrantRequestServiceTest', true, false, 'system', '系统'),
+    ('grant000-0000-0000-0000-000000000011', 'svc-role-grant-approval', 'grant-approval', 'svc-tenant-grant-1', 'ams', true,  'from AuthRoleGrantRequestServiceTest', true, false, 'system', '系统');
+
+-- user-1 already holds the normal role (for the "already holds" guard).
+merge into "auth_role_user" ("id", "role_id", "user_id", "create_user_id", "create_user_name") values
+    ('grant000-0000-0000-0000-000000000020', 'grant000-0000-0000-0000-000000000010', 'grant000-0000-0000-0000-000000000001', 'system', '系统');

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/test-src/io/kudos/ms/auth/core/role/grant/service/AuthRoleGrantRequestServiceTest.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/test-src/io/kudos/ms/auth/core/role/grant/service/AuthRoleGrantRequestServiceTest.kt
@@ -1,0 +1,96 @@
+package io.kudos.ms.auth.core.role.grant.service
+
+import io.kudos.ms.auth.common.grant.enums.GrantRequestStatus
+import io.kudos.ms.auth.core.role.grant.service.iservice.IAuthRoleGrantRequestService
+import io.kudos.ms.auth.core.role.service.iservice.IAuthRoleUserService
+import io.kudos.test.container.annotations.EnabledIfDockerInstalled
+import io.kudos.test.rdb.RdbAndRedisCacheTestBase
+import jakarta.annotation.Resource
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * junit test for AuthRoleGrantRequestService — the role-grant approval workflow.
+ *
+ * Test data source: `AuthRoleGrantRequestServiceTest.sql`
+ *
+ * @author K
+ * @author AI: Claude
+ * @since 1.0.0
+ */
+@EnabledIfDockerInstalled
+class AuthRoleGrantRequestServiceTest : RdbAndRedisCacheTestBase() {
+
+    @Resource
+    private lateinit var service: IAuthRoleGrantRequestService
+
+    @Resource
+    private lateinit var authRoleUserService: IAuthRoleUserService
+
+    private val normalRoleId = "grant000-0000-0000-0000-000000000010"
+    private val approvalRoleId = "grant000-0000-0000-0000-000000000011"
+    private val user1 = "grant000-0000-0000-0000-000000000001" // already holds normalRole
+    private val user2 = "grant000-0000-0000-0000-000000000002"
+
+    @Test
+    fun submit_createsPendingRequest() {
+        val id = service.submit(approvalRoleId, user2, "need access for project X")
+        val req = service.get(id)
+        assertEquals(GrantRequestStatus.PENDING.name, req!!.status)
+        assertEquals(approvalRoleId, req.roleId)
+        assertEquals(user2, req.userId)
+        assertEquals("svc-tenant-grant-1", req.tenantId, "tenant is derived from the role")
+    }
+
+    @Test
+    fun submit_whenUserAlreadyHoldsRole_rejected() {
+        val err = assertFailsWith<IllegalArgumentException> { service.submit(normalRoleId, user1, null) }
+        assertTrue(err.message!!.contains("already holds"))
+    }
+
+    @Test
+    fun submit_duplicatePending_rejected() {
+        service.submit(approvalRoleId, user2, "first")
+        val err = assertFailsWith<IllegalArgumentException> { service.submit(approvalRoleId, user2, "second") }
+        assertTrue(err.message!!.contains("pending"))
+    }
+
+    @Test
+    fun approve_bindsUserAndMarksApproved() {
+        val id = service.submit(approvalRoleId, user2, null)
+        assertFalse(authRoleUserService.exists(approvalRoleId, user2), "not bound before approval")
+
+        assertTrue(service.approve(id, "looks good"))
+
+        assertTrue(authRoleUserService.exists(approvalRoleId, user2), "bound after approval")
+        val req = service.get(id)!!
+        assertEquals(GrantRequestStatus.APPROVED.name, req.status)
+        assertEquals("looks good", req.decisionComment)
+    }
+
+    @Test
+    fun reject_doesNotBind() {
+        val id = service.submit(approvalRoleId, user2, null)
+        assertTrue(service.reject(id, "denied"))
+        assertFalse(authRoleUserService.exists(approvalRoleId, user2), "must NOT be bound after reject")
+        assertEquals(GrantRequestStatus.REJECTED.name, service.get(id)!!.status)
+    }
+
+    @Test
+    fun cancel_marksCancelled() {
+        val id = service.submit(approvalRoleId, user2, null)
+        assertTrue(service.cancel(id))
+        assertEquals(GrantRequestStatus.CANCELLED.name, service.get(id)!!.status)
+    }
+
+    @Test
+    fun approve_nonPending_rejected() {
+        val id = service.submit(approvalRoleId, user2, null)
+        service.reject(id, "no")
+        val err = assertFailsWith<IllegalArgumentException> { service.approve(id, "too late") }
+        assertTrue(err.message!!.contains("already"))
+    }
+}

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-sql/resources/sql/auth/h2/V1.0.0.28__alter_auth_role_add_approval_required.sql
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-sql/resources/sql/auth/h2/V1.0.0.28__alter_auth_role_add_approval_required.sql
@@ -1,0 +1,18 @@
+--region DDL
+-- Approval flow: when approval_required is true, assigning this role to a user should go through
+-- a grant-request → approve cycle (see auth_role_grant_request) rather than an immediate bind.
+--
+-- This column is a *marker only*. The backend ships the request/approve mechanism but does NOT
+-- force the standard batchBind path to reject approval-required roles — whether to enforce that
+-- (vs. leaving direct assignment open for super-admins) is a deployment policy decision, made at
+-- the gateway / calling layer. Default false keeps every existing role on the immediate-bind path.
+alter table "auth_role"
+    add column if not exists "approval_required" boolean default false not null;
+
+comment on column "auth_role"."approval_required" is '分配该角色是否需要审批';
+--endregion DDL
+
+
+--region DML
+-- No backfill: existing roles keep approval_required = false (immediate bind).
+--endregion DML

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-sql/resources/sql/auth/h2/V1.0.0.29__init_auth_role_grant_request.sql
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-sql/resources/sql/auth/h2/V1.0.0.29__init_auth_role_grant_request.sql
@@ -1,0 +1,59 @@
+--region DDL
+-- Role-grant approval request: a pending workflow record for assigning a role to a user.
+--
+-- Lifecycle: PENDING → APPROVED | REJECTED | CANCELLED.
+--   - submit  : requester creates a PENDING row (one per (role,user) that isn't already pending).
+--   - approve : approver flips PENDING → APPROVED and the service performs the actual bind
+--               (reusing AuthRoleUserService.batchBind, so SoD checks still apply).
+--   - reject  : approver flips PENDING → REJECTED (no bind).
+--   - cancel  : requester flips their own PENDING → CANCELLED.
+--
+-- Terminal states (APPROVED/REJECTED/CANCELLED) are immutable; re-requesting needs a new row.
+create table if not exists "auth_role_grant_request"
+(
+    "id"               character(36)          default RANDOM_UUID() not null primary key,
+    "role_id"          character varying(36)  not null,
+    "user_id"          character varying(36)  not null,
+    "tenant_id"        character varying(36)  not null,
+    "status"           character varying(16)  not null,
+    "reason"           character varying(512),
+    "requester_id"     character varying(36),
+    "request_time"     timestamp(6),
+    "approver_id"      character varying(36),
+    "decision_comment" character varying(512),
+    "decision_time"    timestamp(6),
+    "create_user_id"   character varying(36),
+    "create_user_name" character varying(32),
+    "create_time"      timestamp(6),
+    "update_user_id"   character varying(36),
+    "update_user_name" character varying(32),
+    "update_time"      timestamp(6)
+);
+
+comment on table  "auth_role_grant_request" is '角色授予审批请求';
+comment on column "auth_role_grant_request"."id"               is '主键';
+comment on column "auth_role_grant_request"."role_id"          is '申请授予的角色ID';
+comment on column "auth_role_grant_request"."user_id"          is '被授予的用户ID';
+comment on column "auth_role_grant_request"."tenant_id"        is '租户ID';
+comment on column "auth_role_grant_request"."status"           is '状态：PENDING/APPROVED/REJECTED/CANCELLED';
+comment on column "auth_role_grant_request"."reason"           is '申请理由';
+comment on column "auth_role_grant_request"."requester_id"     is '申请人ID';
+comment on column "auth_role_grant_request"."request_time"     is '申请时间';
+comment on column "auth_role_grant_request"."approver_id"      is '审批人ID';
+comment on column "auth_role_grant_request"."decision_comment" is '审批意见';
+comment on column "auth_role_grant_request"."decision_time"    is '审批时间';
+
+-- Approver dashboard query is "PENDING within tenant, newest first" — index the hot columns.
+create index if not exists "idx_auth_role_grant_request_status" on "auth_role_grant_request" ("status");
+create index if not exists "idx_auth_role_grant_request_tenant" on "auth_role_grant_request" ("tenant_id");
+create index if not exists "idx_auth_role_grant_request_user"   on "auth_role_grant_request" ("user_id");
+-- Partial uniqueness (one open request per role+user) is enforced at the service layer because
+-- H2/Postgres partial unique indexes differ in syntax; a full unique would wrongly block a second
+-- request after the first is rejected.
+create index if not exists "idx_auth_role_grant_request_role_user" on "auth_role_grant_request" ("role_id", "user_id");
+--endregion DDL
+
+
+--region DML
+-- No seed data.
+--endregion DML


### PR DESCRIPTION
Adds an opt-in approval gate for role assignments. An admin can request a role for a user; the grant only takes effect after an approver approves it (and the approve step performs the actual bind, so SoD checks still apply).

Schema:
- V1.0.0.28: auth_role.approval_required (marker; default false → existing roles stay on the immediate-bind path). The marker is mechanism-only — whether to *force* approval-required roles through this flow vs. allowing super-admin direct assignment is a deployment policy left to the gateway/calling layer.
- V1.0.0.29: auth_role_grant_request table (role_id, user_id, tenant_id, status, reason, requester/approver ids, decision comment/time, audit cols). Indexed for the "PENDING in tenant" approver-dashboard query.

Lifecycle (IAuthRoleGrantRequestService): PENDING → APPROVED | REJECTED | CANCELLED.
- submit  : validates role/user exist, user doesn't already hold the role, and no open PENDING for the pair; tenant derived from the role.
- approve : re-reads + asserts still PENDING (race guard), performs batchBind (reusing AuthRoleUserService → SoD constraints enforced; a conflicting grant fails the approval and rolls back), then marks APPROVED.
- reject / cancel : terminal transitions, no bind.

Layers:
- PO/Table/DAO (AuthRoleGrantRequest*), findPending() for the dedup guard.
- VOs (kudos-ms-auth-common/grant): submit + decision requests, Row/Detail/Query, GrantRequestStatus enum.
- AuthRoleGrantRequestAdminController → /api/admin/auth/roleGrantRequest: pagingSearch + getDetail (BaseReadOnlyController) plus submit/approve/reject/cancel.
- approval_required surfaced on AuthRole PO/Table + role VOs (CacheEntry, Row, Detail, FormBase/Create/Update) so the admin role form can toggle it.

Tests: AuthRoleGrantRequestServiceTest covers submit/approve(binds)/reject(no bind)/cancel + the dedup, already-holds, and non-pending guards. (Compiles; the auth-core suite can't boot its ApplicationContext on this branch and on main due to a pre-existing "sys_cache table not found" infra error, unrelated to this change.)

Based on feat/auth-sod-exclusion-roles (reuses its SoD-checked batchBind); merge that first. Front-end approval UI — separate PR.