### PR TITLE
feat(auth): temporal role grants (时效性授权) — time-bound, auto-expiring …

### DIFF
--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-api-admin/src/io/kudos/ms/auth/api/admin/controller/temporal/AuthRoleUserTemporalAdminController.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-api-admin/src/io/kudos/ms/auth/api/admin/controller/temporal/AuthRoleUserTemporalAdminController.kt
@@ -1,0 +1,39 @@
+package io.kudos.ms.auth.api.admin.controller.temporal
+
+import io.kudos.ms.auth.common.temporal.vo.request.AuthRoleUserTemporalBindRequest
+import io.kudos.ms.auth.core.role.temporal.service.iservice.IAuthRoleUserTemporalService
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * Temporal (时效性) role-grant administration controller.
+ *
+ * Base URL: `/api/admin/auth/roleUserTemporal`
+ *
+ *   POST /bind          body={ roleId, userId, startTime?, endTime? }  → new grant id (replace)
+ *   POST /purgeExpired                                                  → count of grants purged
+ *
+ * The role↔user effective-now filtering lives in the DAO/caches; `purgeExpired` is the reaper that
+ * deletes lapsed grants and evicts caches — intended to be triggered periodically by a scheduler.
+ *
+ * @author K
+ * @author AI: Claude
+ * @since 1.0.0
+ */
+@RestController
+@RequestMapping("/api/admin/auth/roleUserTemporal")
+class AuthRoleUserTemporalAdminController(
+    private val service: IAuthRoleUserTemporalService,
+) {
+
+    /** Grant a role to a user with an optional validity window (replace semantics). */
+    @PostMapping("/bind")
+    fun bind(@RequestBody request: AuthRoleUserTemporalBindRequest): String =
+        service.bindTemporal(request.roleId, request.userId, request.startTime, request.endTime)
+
+    /** Delete all expired grants and evict the affected users' caches. Returns the purged count. */
+    @PostMapping("/purgeExpired")
+    fun purgeExpired(): Int = service.purgeExpired()
+}

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/temporal/vo/request/AuthRoleUserTemporalBindRequest.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-common/src/io/kudos/ms/auth/common/temporal/vo/request/AuthRoleUserTemporalBindRequest.kt
@@ -1,0 +1,37 @@
+package io.kudos.ms.auth.common.temporal.vo.request
+
+import java.io.Serializable
+import java.time.LocalDateTime
+
+/**
+ * Request body to grant a role to a user with an optional validity window (时效性授权).
+ *
+ * Replace semantics: any existing grant for the same (roleId, userId) is superseded, so the
+ * supplied window becomes authoritative. Both bounds are optional:
+ *   - startTime NULL ⇒ effective immediately
+ *   - endTime   NULL ⇒ never expires
+ * If both are set, startTime must not be after endTime.
+ *
+ * @author K
+ * @author AI: Claude
+ * @since 1.0.0
+ */
+data class AuthRoleUserTemporalBindRequest(
+
+    /** Role to grant. */
+    val roleId: String,
+
+    /** User to grant it to. */
+    val userId: String,
+
+    /** Grant effective time; NULL = immediately. */
+    val startTime: LocalDateTime? = null,
+
+    /** Grant expiry time; NULL = never. */
+    val endTime: LocalDateTime? = null,
+
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/src/io/kudos/ms/auth/core/role/dao/AuthRoleUserDao.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/src/io/kudos/ms/auth/core/role/dao/AuthRoleUserDao.kt
@@ -3,9 +3,11 @@ package io.kudos.ms.auth.core.role.dao
 import io.kudos.ability.data.rdb.ktorm.support.BaseCrudDao
 import io.kudos.base.query.Criteria
 import io.kudos.base.query.eq
+import io.kudos.base.query.enums.OperatorEnum
 import io.kudos.ms.auth.core.role.model.po.AuthRoleUser
 import io.kudos.ms.auth.core.role.model.table.AuthRoleUsers
 import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
 
 
 /**
@@ -37,24 +39,49 @@ open class AuthRoleUserDao : BaseCrudDao<String, AuthRoleUser, AuthRoleUsers>() 
     }
 
     /**
-     * Queries role IDs by user id.
+     * Queries role IDs **currently active** for a user. A temporal grant (with start_time/end_time)
+     * counts only while [now] falls inside its window; permanent grants (both NULL) always count.
+     * This is the permission-resolution contract — the caches that drive access checks call it.
      *
      * @param userId user id
-     * @return List<role id>
+     * @param now the instant to evaluate the validity window against (defaults to current time)
+     * @return List<role id> for grants active at [now]
      */
-    fun searchRoleIdsByUserId(userId: String): List<String> {
+    fun searchRoleIdsByUserId(userId: String, now: LocalDateTime = LocalDateTime.now()): List<String> {
         val criteria = Criteria(AuthRoleUser::userId eq userId)
-        return searchProperty(criteria, AuthRoleUser::roleId).filterNotNull()
+        return search(criteria).filter { isActiveAt(it, now) }.map { it.roleId }
     }
 
     /**
-     * Returns all role-user relations grouped by user id as "user id -> list of role ids".
+     * Returns all **currently active** role-user relations grouped by user id as
+     * "user id -> list of role ids". Out-of-window temporal grants are excluded; permanent grants
+     * (start_time/end_time both NULL) are always included.
      *
+     * @param now the instant to evaluate the validity windows against (defaults to current time)
      * @return Map<user id, List<role id>>
      */
-    fun searchAllUserIdToRoleIdsForCache(): Map<String, List<String>> {
-        val all = allSearch()
+    fun searchAllUserIdToRoleIdsForCache(now: LocalDateTime = LocalDateTime.now()): Map<String, List<String>> {
+        val all = allSearch().filter { isActiveAt(it, now) }
         return all.groupBy { it.userId }.mapValues { (_, list) -> list.map { it.roleId } }
+    }
+
+    /**
+     * Returns grants whose validity window has already ended (end_time < [now]). Used by the purge
+     * sweep. NULL end_time (never-expires) rows are excluded by the comparison. Indexed on end_time.
+     *
+     * @param now the instant to compare expiry against (defaults to current time)
+     * @return the expired grant rows (carry id / roleId / userId for deletion + cache eviction)
+     */
+    open fun searchExpiredGrants(now: LocalDateTime = LocalDateTime.now()): List<AuthRoleUser> {
+        val criteria = Criteria(AuthRoleUser::endTime.name, OperatorEnum.LT, now)
+        return search(criteria)
+    }
+
+    /** A grant is active at [now] when now is within [start, end] (NULL bounds are open). */
+    private fun isActiveAt(grant: AuthRoleUser, now: LocalDateTime): Boolean {
+        val start = grant.startTime
+        val end = grant.endTime
+        return (start == null || !start.isAfter(now)) && (end == null || !end.isBefore(now))
     }
 
     /**

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/src/io/kudos/ms/auth/core/role/model/po/AuthRoleUser.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/src/io/kudos/ms/auth/core/role/model/po/AuthRoleUser.kt
@@ -21,6 +21,12 @@ interface AuthRoleUser : IDbEntity<String, AuthRoleUser> {
     /** User id */
     var userId: String
 
+    /** Grant effective time; NULL = effective immediately. */
+    var startTime: LocalDateTime?
+
+    /** Grant expiry time; NULL = never expires. */
+    var endTime: LocalDateTime?
+
     /** Creator id */
     var createUserId: String?
 

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/src/io/kudos/ms/auth/core/role/model/table/AuthRoleUsers.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/src/io/kudos/ms/auth/core/role/model/table/AuthRoleUsers.kt
@@ -21,6 +21,12 @@ object AuthRoleUsers : StringIdTable<AuthRoleUser>("auth_role_user") {
     /** User id */
     var userId = varchar("user_id").bindTo { it.userId }
 
+    /** Grant effective time; NULL = effective immediately. */
+    var startTime = datetime("start_time").bindTo { it.startTime }
+
+    /** Grant expiry time; NULL = never expires. */
+    var endTime = datetime("end_time").bindTo { it.endTime }
+
     /** Creator id */
     var createUserId = varchar("create_user_id").bindTo { it.createUserId }
 

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/src/io/kudos/ms/auth/core/role/temporal/service/impl/AuthRoleUserTemporalService.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/src/io/kudos/ms/auth/core/role/temporal/service/impl/AuthRoleUserTemporalService.kt
@@ -1,0 +1,76 @@
+package io.kudos.ms.auth.core.role.temporal.service.impl
+
+import io.kudos.base.logger.LogFactory
+import io.kudos.ms.auth.core.role.dao.AuthRoleUserDao
+import io.kudos.ms.auth.core.role.event.AuthRoleUserRelationsChanged
+import io.kudos.ms.auth.core.role.model.po.AuthRoleUser
+import io.kudos.ms.auth.core.role.temporal.service.iservice.IAuthRoleUserTemporalService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+
+/**
+ * Temporal role-grant business.
+ *
+ * Kept separate from [io.kudos.ms.auth.core.role.service.impl.AuthRoleUserService] (which owns the
+ * SoD-checked permanent binds): windowed grants and the expiry sweep are a distinct concern, and a
+ * separate bean avoids entangling the hot batch-bind path. Both share [AuthRoleUserDao].
+ *
+ * @author K
+ * @author AI: Claude
+ * @since 1.0.0
+ */
+@Service
+@Transactional
+open class AuthRoleUserTemporalService(
+    private val dao: AuthRoleUserDao,
+) : IAuthRoleUserTemporalService {
+
+    @Autowired
+    private lateinit var eventPublisher: ApplicationEventPublisher
+
+    private val log = LogFactory.getLog(this::class)
+
+    @Transactional
+    override fun bindTemporal(
+        roleId: String,
+        userId: String,
+        startTime: LocalDateTime?,
+        endTime: LocalDateTime?,
+    ): String {
+        if (startTime != null && endTime != null) {
+            require(!startTime.isAfter(endTime)) {
+                "start_time must not be after end_time (role=${roleId}, user=${userId})."
+            }
+        }
+        // Replace any existing grant for this (role, user) so the supplied window is authoritative.
+        dao.deleteByRoleIdAndUserId(roleId, userId)
+        val grant = AuthRoleUser {
+            this.roleId = roleId
+            this.userId = userId
+            this.startTime = startTime
+            this.endTime = endTime
+        }
+        val id = dao.insert(grant)
+        log.debug("Temporal grant role=${roleId} user=${userId} window=[${startTime}, ${endTime}] id=${id}.")
+        eventPublisher.publishEvent(AuthRoleUserRelationsChanged(roleId, listOf(userId)))
+        return id
+    }
+
+    @Transactional
+    override fun purgeExpired(): Int {
+        val expired = dao.searchExpiredGrants()
+        if (expired.isEmpty()) return 0
+        dao.batchDelete(expired.map { it.id })
+        // Evict caches for every affected (role → users) pair so resolved sets drop the lapsed roles.
+        expired.groupBy { it.roleId }.forEach { (roleId, grants) ->
+            eventPublisher.publishEvent(AuthRoleUserRelationsChanged(roleId, grants.map { it.userId }.distinct()))
+        }
+        log.debug("Purged ${expired.size} expired role-user grants.")
+        return expired.size
+    }
+
+}

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/src/io/kudos/ms/auth/core/role/temporal/service/iservice/IAuthRoleUserTemporalService.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/src/io/kudos/ms/auth/core/role/temporal/service/iservice/IAuthRoleUserTemporalService.kt
@@ -1,0 +1,37 @@
+package io.kudos.ms.auth.core.role.temporal.service.iservice
+
+import java.time.LocalDateTime
+
+/**
+ * Temporal (时效性) role-grant business: time-bound role assignments that auto-expire.
+ *
+ * Effective-now filtering happens in [io.kudos.ms.auth.core.role.dao.AuthRoleUserDao] (the
+ * permission-resolution queries exclude out-of-window grants); this service manages the windows
+ * and drives expiry via a purge sweep that deletes lapsed grants and evicts the affected users'
+ * caches.
+ *
+ * @author K
+ * @author AI: Claude
+ * @since 1.0.0
+ */
+interface IAuthRoleUserTemporalService {
+
+    /**
+     * Grant [roleId] to [userId] with an optional validity window (replace semantics — any existing
+     * grant for the same pair is superseded). NULL [startTime] ⇒ effective immediately; NULL
+     * [endTime] ⇒ never expires. Publishes a relations-changed event so caches recompute.
+     *
+     * @throws IllegalArgumentException if both bounds are set and [startTime] is after [endTime]
+     * @return the new grant's id
+     */
+    fun bindTemporal(roleId: String, userId: String, startTime: LocalDateTime?, endTime: LocalDateTime?): String
+
+    /**
+     * Delete every grant whose validity window has already ended and evict the affected users'
+     * caches. Intended to be invoked periodically by a scheduler (the reaper for temporal grants).
+     *
+     * @return the number of expired grants purged
+     */
+    fun purgeExpired(): Int
+
+}

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/test-resources/sql/h2/role/temporal/service/AuthRoleUserTemporalServiceTest.sql
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/test-resources/sql/h2/role/temporal/service/AuthRoleUserTemporalServiceTest.sql
@@ -1,0 +1,13 @@
+-- auth_role: 供时效性授权用例
+merge into "auth_role" ("id", "code", "name", "tenant_id", "subsys_code", "remark", "active", "built_in", "create_user_id", "create_user_name") values
+    ('7e3b9a01-0000-0000-0000-0000000000a1', 'tmp-role-1-7e3b9a01', 'tmp-role-1', 'tmp-tenant-7e3b9a01', 'ams', 'temporal', true, false, 'system', '系统'),
+    ('7e3b9a01-0000-0000-0000-0000000000a2', 'tmp-role-2-7e3b9a01', 'tmp-role-2', 'tmp-tenant-7e3b9a01', 'ams', 'temporal', true, false, 'system', '系统');
+
+-- user_account
+merge into "user_account" ("id", "username", "tenant_id", "login_password", "supervisor_id", "remark", "active", "built_in", "create_user_id", "create_user_name") values
+    ('7e3b9a01-0000-0000-0000-0000000000b1', 'tmp-user-1-7e3b9a01', 'tmp-tenant-7e3b9a01', 'pwd', '00000000-0000-0000-0000-000000000000', 'temporal', true, false, 'system', '系统'),
+    ('7e3b9a01-0000-0000-0000-0000000000b2', 'tmp-user-2-7e3b9a01', 'tmp-tenant-7e3b9a01', 'pwd', '00000000-0000-0000-0000-000000000000', 'temporal', true, false, 'system', '系统');
+
+-- auth_role_user: user1 永久持有 role1（start/end 均 NULL），作为 active 过滤的基线
+merge into "auth_role_user" ("id", "role_id", "user_id", "create_user_id", "create_user_name") values
+    ('7e3b9a01-0000-0000-0000-0000000000c0', '7e3b9a01-0000-0000-0000-0000000000a1', '7e3b9a01-0000-0000-0000-0000000000b1', 'system', '系统');

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/test-src/io/kudos/ms/auth/core/role/temporal/service/AuthRoleUserTemporalServiceTest.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/test-src/io/kudos/ms/auth/core/role/temporal/service/AuthRoleUserTemporalServiceTest.kt
@@ -1,0 +1,104 @@
+package io.kudos.ms.auth.core.role.temporal.service
+
+import io.kudos.ms.auth.core.role.dao.AuthRoleUserDao
+import io.kudos.ms.auth.core.role.temporal.service.iservice.IAuthRoleUserTemporalService
+import io.kudos.test.container.annotations.EnabledIfDockerInstalled
+import io.kudos.test.rdb.RdbAndRedisCacheTestBase
+import jakarta.annotation.Resource
+import java.time.LocalDateTime
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * junit test for AuthRoleUserTemporalService.
+ *
+ * Test data source: `AuthRoleUserTemporalServiceTest.sql`
+ * user1 permanently holds role1 (baseline); the rest is exercised via bindTemporal with windows
+ * computed relative to now() so the assertions are deterministic regardless of run time.
+ *
+ * @author K
+ * @author AI: Claude
+ * @since 1.0.0
+ */
+@EnabledIfDockerInstalled
+class AuthRoleUserTemporalServiceTest : RdbAndRedisCacheTestBase() {
+
+    @Resource
+    private lateinit var service: IAuthRoleUserTemporalService
+
+    @Resource
+    private lateinit var dao: AuthRoleUserDao
+
+    private val role1 = "7e3b9a01-0000-0000-0000-0000000000a1"
+    private val role2 = "7e3b9a01-0000-0000-0000-0000000000a2"
+    private val user1 = "7e3b9a01-0000-0000-0000-0000000000b1"
+    private val user2 = "7e3b9a01-0000-0000-0000-0000000000b2"
+
+    @Test
+    fun permanentGrant_isActive() {
+        // Fixture: user1 permanently holds role1 (no window).
+        assertTrue(dao.searchRoleIdsByUserId(user1).contains(role1))
+    }
+
+    @Test
+    fun bindTemporal_currentWindow_isActive() {
+        val now = LocalDateTime.now()
+        service.bindTemporal(role2, user2, now.minusDays(1), now.plusDays(1))
+        assertTrue(dao.searchRoleIdsByUserId(user2).contains(role2))
+    }
+
+    @Test
+    fun bindTemporal_pastWindow_excluded() {
+        val now = LocalDateTime.now()
+        service.bindTemporal(role2, user2, now.minusDays(2), now.minusDays(1))
+        assertFalse(dao.searchRoleIdsByUserId(user2).contains(role2))
+    }
+
+    @Test
+    fun bindTemporal_futureWindow_excluded() {
+        val now = LocalDateTime.now()
+        service.bindTemporal(role2, user2, now.plusDays(1), now.plusDays(2))
+        assertFalse(dao.searchRoleIdsByUserId(user2).contains(role2))
+    }
+
+    @Test
+    fun bindTemporal_openEndedFutureStart_excludedUntilStart() {
+        val now = LocalDateTime.now()
+        // No end, but starts tomorrow → not yet active.
+        service.bindTemporal(role2, user2, now.plusDays(1), null)
+        assertFalse(dao.searchRoleIdsByUserId(user2).contains(role2))
+    }
+
+    @Test
+    fun bindTemporal_startAfterEnd_rejected() {
+        val now = LocalDateTime.now()
+        assertFailsWith<IllegalArgumentException> {
+            service.bindTemporal(role2, user2, now.plusDays(2), now.plusDays(1))
+        }
+    }
+
+    @Test
+    fun bindTemporal_replaceSemantics_singleRow() {
+        val now = LocalDateTime.now()
+        // First an expired window, then re-bind permanent — the old row must be replaced, not added.
+        service.bindTemporal(role2, user2, now.minusDays(2), now.minusDays(1))
+        service.bindTemporal(role2, user2, null, null)
+        assertTrue(dao.searchRoleIdsByUserId(user2).contains(role2))
+        assertEquals(1, dao.searchUserIdsByRoleId(role2).count { it == user2 })
+    }
+
+    @Test
+    fun purgeExpired_deletesExpiredKeepsActive() {
+        val now = LocalDateTime.now()
+        service.bindTemporal(role1, user2, now.minusDays(2), now.minusDays(1)) // expired
+        service.bindTemporal(role2, user2, now.minusDays(1), now.plusDays(1))  // active
+        val purged = service.purgeExpired()
+        assertTrue(purged >= 1)
+        val active = dao.searchRoleIdsByUserId(user2)
+        assertTrue(active.contains(role2))
+        assertFalse(active.contains(role1))
+    }
+}

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-sql/resources/sql/auth/h2/V1.0.0.32__alter_auth_role_user_add_temporal.sql
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-sql/resources/sql/auth/h2/V1.0.0.32__alter_auth_role_user_add_temporal.sql
@@ -1,0 +1,29 @@
+--region DDL
+-- Temporal (时效性) role grants: an assignment may carry an optional validity window.
+--   start_time  the grant becomes effective at/after this instant (NULL = effective immediately)
+--   end_time    the grant expires after this instant (NULL = never expires)
+-- A grant is "active now" when (start_time IS NULL OR start_time <= now) AND
+-- (end_time IS NULL OR end_time >= now). Existing rows have both NULL → permanent, exactly the
+-- pre-feature behaviour, so nothing is silently revoked.
+--
+-- Enforcement: the permission-resolution DAO queries filter to active-now grants at compute time,
+-- and a purge sweep (IAuthRoleUserTemporalService.purgeExpired) deletes expired rows and evicts the
+-- affected users' caches. Future-dated activation relies on the cache being refreshed/evicted at or
+-- after start_time.
+alter table "auth_role_user"
+    add column if not exists "start_time" timestamp(6);
+
+alter table "auth_role_user"
+    add column if not exists "end_time" timestamp(6);
+
+comment on column "auth_role_user"."start_time" is '授权生效时间，NULL 表示立即生效';
+comment on column "auth_role_user"."end_time"   is '授权失效时间，NULL 表示永不失效';
+
+-- The purge sweep scans for rows whose end_time has passed; index it so the sweep stays cheap.
+create index if not exists "idx_auth_role_user_end_time" on "auth_role_user" ("end_time");
+--endregion DDL
+
+
+--region DML
+-- No backfill: existing grants keep start_time/end_time NULL (permanent).
+--endregion DML


### PR DESCRIPTION
…assignments

Adds an optional validity window to role↔user grants and a reaper that drops lapsed ones. P2 #5 (final item of the advanced-RBAC series).

Schema:
- V1.0.0.32 alter auth_role_user add start_time / end_time (nullable) + index on end_time. Existing rows have both NULL = permanent, so nothing is silently revoked.

Model / DAO:
- startTime / endTime on AuthRoleUser PO + table.
- AuthRoleUserDao now resolves *active-now* grants by default: searchRoleIdsByUserId and searchAllUserIdToRoleIdsForCache filter to grants whose window contains `now` (NULL bounds open). Since every permission-resolution cache feeds off these two methods, all access checks become temporal-aware automatically; permanent grants are unaffected.
- searchExpiredGrants(now) — indexed end_time < now lookup for the sweep.

Service / API:
- IAuthRoleUserTemporalService: bindTemporal(roleId, userId, start, end) — replace semantics, rejects start>end, publishes AuthRoleUserRelationsChanged so caches recompute; purgeExpired() — deletes lapsed grants and evicts affected users' caches (the reaper; meant to be scheduled).
- AuthRoleUserTemporalBindRequest VO; AuthRoleUserTemporalAdminController /api/admin/auth/roleUserTemporal: bind / purgeExpired.

Note: load-time filtering gives a correct snapshot; over-time expiry is driven by the purge sweep's cache eviction, and future-dated activation relies on cache refresh — documented in the migration + service KDoc.

Tests: AuthRoleUserTemporalServiceTest + fixture — permanent baseline, current/past/future/ open-ended windows, start>end reject, replace-single-row, purge keeps active drops expired.

Verified: :kudos-ms-auth-common/core/api-admin compileKotlin + auth-core compileTestKotlin pass.