### PR TITLE
chore(kotlin): upgrade to Kotlin 2.4.0 and adopt stable kotlin.uuid.Uuid

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # https://docs.gradle.org/current/userguide/platforms.html#sub::toml-dependencies-format
 
 [versions]
-kotlin = "2.3.21"
+kotlin = "2.4.0"
 kotlinxDatetime = "0.8.0"
 kotlinxSerializationJSON = "1.11.0"
 kotlinxCoroutines = "1.11.0"

--- a/kudos-ability/kudos-ability-cache/kudos-ability-cache-common/src/io/kudos/ability/cache/common/core/hash/MixHashCacheManager.kt
+++ b/kudos-ability/kudos-ability-cache/kudos-ability-cache-common/src/io/kudos/ability/cache/common/core/hash/MixHashCacheManager.kt
@@ -10,7 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
-import java.util.UUID
+import io.kudos.base.lang.string.RandomStringKit
 
 /**
  * Hash cache strategy wrapper manager: creates an [IHashCache] view (local / remote / two-tier) for each hash cache name based on configuration.
@@ -48,7 +48,7 @@ class MixHashCacheManager {
     private var nodeId: String? = null
 
     private val hashCaches: MutableMap<String, IHashCache> = mutableMapOf()
-    private val effectiveNodeId: String by lazy { nodeId ?: UUID.randomUUID().toString() }
+    private val effectiveNodeId: String by lazy { nodeId ?: RandomStringKit.uuid() }
 
     /**
      * Invoked after system initialization completes; loads all hash cache configurations and creates the strategy wrapper views.

--- a/kudos-ability/kudos-ability-cache/kudos-ability-cache-common/src/io/kudos/ability/cache/common/notify/CacheOperatorVo.kt
+++ b/kudos-ability/kudos-ability-cache/kudos-ability-cache-common/src/io/kudos/ability/cache/common/notify/CacheOperatorVo.kt
@@ -8,7 +8,7 @@ import io.kudos.context.kit.SpringKit
 import org.springframework.beans.factory.NoSuchBeanDefinitionException
 import java.io.Serial
 import java.io.Serializable
-import java.util.UUID
+import io.kudos.base.lang.string.RandomStringKit
 
 /**
  * Cache operation value object.
@@ -58,7 +58,7 @@ class CacheOperatorVo(
      * Generated when the object is constructed; null when deserialized from an old node (Java serialization
      * compatibility for new fields). Consumers must handle null.
      */
-    var messageId: String? = UUID.randomUUID().toString()
+    var messageId: String? = RandomStringKit.uuid()
 
     /**
      * Sender node id; populated in [doNotify]. Helps consumers identify loopback / troubleshoot cross-node issues.

--- a/kudos-ability/kudos-ability-cache/kudos-ability-cache-remote/kudos-ability-cache-remote-redis/src/io/kudos/ability/cache/remote/redis/init/RedisCacheAutoConfiguration.kt
+++ b/kudos-ability/kudos-ability-cache/kudos-ability-cache-remote/kudos-ability-cache-remote-redis/src/io/kudos/ability/cache/remote/redis/init/RedisCacheAutoConfiguration.kt
@@ -39,7 +39,7 @@ import org.springframework.data.redis.listener.ChannelTopic
 import org.springframework.data.redis.listener.RedisMessageListenerContainer
 import org.springframework.data.redis.serializer.RedisSerializationContext
 import java.time.Duration
-import java.util.UUID
+import io.kudos.base.lang.string.RandomStringKit
 
 
 /**
@@ -187,7 +187,7 @@ open class RedisCacheAutoConfiguration : BaseCacheConfiguration(), IComponentIni
     @Bean("cacheNodeId")
     @ConditionalOnMissingBean(name = ["cacheNodeId"])
     open fun cacheNodeId(redisCacheProperties: RedisCacheProperties): String =
-        redisCacheProperties.nodeId?.trim()?.takeIf { it.isNotBlank() } ?: UUID.randomUUID().toString()
+        redisCacheProperties.nodeId?.trim()?.takeIf { it.isNotBlank() } ?: RandomStringKit.uuid()
 
     /** Cache message SPI implementation (send + receive loopback + error log on deserialization failure). */
     @Bean

--- a/kudos-ability/kudos-ability-comm/kudos-ability-comm-websocket/kudos-ability-comm-websocket-ktor/src/io/kudos/ability/comm/websocket/ktor/session/KudosWebSocketSession.kt
+++ b/kudos-ability/kudos-ability-comm/kudos-ability-comm-websocket/kudos-ability-comm-websocket-ktor/src/io/kudos/ability/comm/websocket/ktor/session/KudosWebSocketSession.kt
@@ -5,7 +5,7 @@ import io.ktor.websocket.CloseReason
 import io.ktor.websocket.Frame
 import io.ktor.websocket.close
 import io.ktor.websocket.send
-import java.util.UUID
+import io.kudos.base.lang.string.RandomStringKit
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -34,7 +34,7 @@ import java.util.concurrent.ConcurrentHashMap
  */
 class KudosWebSocketSession(
     val raw: DefaultWebSocketServerSession,
-    override val sessionId: String = UUID.randomUUID().toString(),
+    override val sessionId: String = RandomStringKit.uuid(),
     override val userId: String? = null,
     override val tenantId: String? = null,
 ) : KudosWebSocketSessionRef {

--- a/kudos-ability/kudos-ability-distributed/kudos-ability-distributed-client/kudos-ability-distributed-client-feign/src/io/kudos/ability/distributed/client/feign/interceptor/GlobalHeaderRequestInterceptor.kt
+++ b/kudos-ability/kudos-ability-distributed/kudos-ability-distributed-client/kudos-ability-distributed-client-feign/src/io/kudos/ability/distributed/client/feign/interceptor/GlobalHeaderRequestInterceptor.kt
@@ -11,7 +11,7 @@ import org.springframework.core.annotation.AnnotationAwareOrderComparator
 import java.nio.charset.StandardCharsets
 import java.time.Clock
 import java.util.Base64
-import java.util.UUID
+import io.kudos.base.lang.string.RandomStringKit
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 
@@ -56,7 +56,7 @@ import javax.crypto.spec.SecretKeySpec
 class GlobalHeaderRequestInterceptor(
     private val properties: OpenFeignProperties = OpenFeignProperties(),
     private val clock: Clock = Clock.systemUTC(),
-    private val nonceSupplier: () -> String = { UUID.randomUUID().toString() }
+    private val nonceSupplier: () -> String = { RandomStringKit.uuid() }
 ) : RequestInterceptor {
 
     /**
@@ -105,7 +105,7 @@ class GlobalHeaderRequestInterceptor(
         // tracing can stitch them into one trace. The previous implementation only generated without
         // writing back, producing a new UUID per outbound call and fragmenting the trace.
         val traceKey = context.traceKey?.takeIf { it.isNotBlank() }
-            ?: UUID.randomUUID().toString().also { context.traceKey = it }
+            ?: RandomStringKit.uuid().also { context.traceKey = it }
         val dataSourceId = context.dataSourceId
         requestTemplate.header(Consts.RequestHeader.TENANT_ID, tenantId.toString())
         requestTemplate.header(Consts.RequestHeader.SUB_SYS_CODE, subSysCode)

--- a/kudos-ability/kudos-ability-security/kudos-ability-security-jwt/src/io/kudos/ability/security/jwt/init/properties/SecurityJwtClaimProperties.kt
+++ b/kudos-ability/kudos-ability-security/kudos-ability-security-jwt/src/io/kudos/ability/security/jwt/init/properties/SecurityJwtClaimProperties.kt
@@ -2,7 +2,7 @@ package io.kudos.ability.security.jwt.init.properties
 
 import org.springframework.boot.context.properties.ConfigurationProperties
 import java.time.Instant
-import java.util.UUID
+import io.kudos.base.lang.string.RandomStringKit
 
 /**
  * Default-claim configuration for tokens minted by [io.kudos.ability.security.jwt.support.JwtParametersTool].
@@ -70,7 +70,7 @@ class SecurityJwtClaimProperties {
 
     /** Resolves [jti]; `"uuid()"` → fresh UUID (no hyphens); otherwise empty string. */
     fun resolveJwtId(): String =
-        if (jti == UUID_FN) UUID.randomUUID().toString().replace("-", "") else ""
+        if (jti == UUID_FN) RandomStringKit.uuidWithoutDelimiter() else ""
 
     companion object {
         private const val NOW = "now()"

--- a/kudos-ability/kudos-ability-web/kudos-ability-web-ktor/src/io/kudos/ability/web/ktor/plugins/KudosContextPlugin.kt
+++ b/kudos-ability/kudos-ability-web/kudos-ability-web-ktor/src/io/kudos/ability/web/ktor/plugins/KudosContextPlugin.kt
@@ -5,7 +5,7 @@ import io.ktor.util.*
 import io.kudos.context.core.KudosContext
 import io.kudos.context.core.KudosContextElement
 import kotlinx.coroutines.withContext
-import java.util.UUID
+import io.kudos.base.lang.string.RandomStringKit
 
 /**
  * Key used to store the [KudosContext] in Ktor call attributes.
@@ -55,7 +55,7 @@ fun ApplicationCall.kudosContext(): KudosContext =
  * install(KudosContextPlugin) {
  *     factory = { call ->
  *         KudosContext().apply {
- *             traceKey = call.request.headers["X-Trace-Id"] ?: UUID.randomUUID().toString()
+ *             traceKey = call.request.headers["X-Trace-Id"] ?: RandomStringKit.uuid()
  *             // other custom fields...
  *         }
  *     }
@@ -88,7 +88,7 @@ class KudosContextPlugin private constructor(
          */
         var factory: (ApplicationCall) -> KudosContext = { call ->
             KudosContext().apply {
-                traceKey = call.request.headers["X-Trace-Id"] ?: UUID.randomUUID().toString()
+                traceKey = call.request.headers["X-Trace-Id"] ?: RandomStringKit.uuid()
             }
         }
     }

--- a/kudos-ability/kudos-ability-web/kudos-ability-web-springmvc/src/io/kudos/ability/web/springmvc/filter/WebContextInitFilter.kt
+++ b/kudos-ability/kudos-ability-web/kudos-ability-web-springmvc/src/io/kudos/ability/web/springmvc/filter/WebContextInitFilter.kt
@@ -11,7 +11,7 @@ import jakarta.servlet.FilterChain
 import jakarta.servlet.ServletRequest
 import jakarta.servlet.ServletResponse
 import jakarta.servlet.http.HttpServletRequest
-import java.util.UUID
+import io.kudos.base.lang.string.RandomStringKit
 
 
 /**
@@ -52,7 +52,7 @@ open class WebContextInitFilter : IWebContextInitFilter {
             context.addHeaderAttributes(name to request.getHeader(name))
         }
         context.traceKey = request.getHeader(Consts.RequestHeader.TRACE_KEY)?.takeIf { it.isNotBlank() }
-            ?: UUID.randomUUID().toString()
+            ?: RandomStringKit.uuid()
 
         // client info
         val clientInfoBuilder = ClientInfo.Builder()

--- a/kudos-base/src/io/kudos/base/lang/string/RandomStringKit.kt
+++ b/kudos-base/src/io/kudos/base/lang/string/RandomStringKit.kt
@@ -4,8 +4,8 @@ import io.kudos.base.lang.string.RandomStringKit.random
 import org.apache.commons.lang3.RandomStringUtils
 import java.security.SecureRandom
 import java.util.Random
-import java.util.UUID
 import kotlin.math.abs
+import kotlin.uuid.Uuid
 
 /**
  * Random string utilities.
@@ -18,22 +18,22 @@ object RandomStringKit {
     private val random = SecureRandom()
 
     /**
-     * Wraps Java's UUID.
+     * Wraps Kotlin's Uuid.
      *
      * @return a UUID delimited with "-"
      * @author K
      * @since 1.0.0
      */
-    fun uuid(): String = UUID.randomUUID().toString()
+    fun uuid(): String = Uuid.random().toString()
 
     /**
-     * Wraps Java's UUID without "-" delimiters.
+     * Wraps Kotlin's Uuid without "-" delimiters.
      *
      * @return a UUID without "-" delimiters
      * @author K
      * @since 1.0.0
      */
-    fun uuidWithoutDelimiter(): String = UUID.randomUUID().toString().replace("-".toRegex(), "")
+    fun uuidWithoutDelimiter(): String = Uuid.random().toHexString()
 
     /**
      * Randomly generates a Long via SecureRandom.

--- a/kudos-context/src/io/kudos/context/retry/AbstractFailedDataHandler.kt
+++ b/kudos-context/src/io/kudos/context/retry/AbstractFailedDataHandler.kt
@@ -6,7 +6,7 @@ import java.io.File
 import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Paths
-import java.util.UUID
+import io.kudos.base.lang.string.RandomStringKit
 
 /**
  * Abstract base class for failed-data handlers.
@@ -50,7 +50,7 @@ abstract class AbstractFailedDataHandler<T> : IFailedDataHandler<T> {
      *
      * File naming:
      * - Timestamp: System.currentTimeMillis(), used for ordering
-     * - UUID: UUID.randomUUID(), ensures uniqueness
+     * - UUID: RandomStringKit.uuid(), ensures uniqueness
      * - Format: timestamp-UUID.json
      *
      * Exception handling:
@@ -64,7 +64,7 @@ abstract class AbstractFailedDataHandler<T> : IFailedDataHandler<T> {
     override fun persistFailedData(data: T): String = try {
         val dir = Paths.get(filePath()).resolve(businessType)
         if (Files.notExists(dir)) Files.createDirectories(dir)
-        val file = dir.resolve("${System.currentTimeMillis()}-${UUID.randomUUID()}.json")
+        val file = dir.resolve("${System.currentTimeMillis()}-${RandomStringKit.uuid()}.json")
         Files.write(file, JsonKit.writeAnyAsBytes(data))
         file.toAbsolutePath().toString()
     } catch (e: IOException) {

--- a/kudos-ms/kudos-ms-sys/kudos-ms-sys-core/test-src/io/kudos/ms/sys/core/accessrule/event/SysAccessRuleEventPublishingTest.kt
+++ b/kudos-ms/kudos-ms-sys/kudos-ms-sys-core/test-src/io/kudos/ms/sys/core/accessrule/event/SysAccessRuleEventPublishingTest.kt
@@ -87,5 +87,5 @@ open class AccessRuleEventCaptor {
         raw.clear()
     }
 
-    inline fun <reified T> lastOf(): T? = raw.filterIsInstance<T>().lastOrNull()
+    final inline fun <reified T> lastOf(): T? = raw.filterIsInstance<T>().lastOrNull()
 }

--- a/kudos-ms/kudos-ms-sys/kudos-ms-sys-core/test-src/io/kudos/ms/sys/core/dict/event/SysDictEventPublishingTest.kt
+++ b/kudos-ms/kudos-ms-sys/kudos-ms-sys-core/test-src/io/kudos/ms/sys/core/dict/event/SysDictEventPublishingTest.kt
@@ -86,5 +86,5 @@ open class DictEventCaptor {
         raw.clear()
     }
 
-    inline fun <reified T> lastOf(): T? = raw.filterIsInstance<T>().lastOrNull()
+    final inline fun <reified T> lastOf(): T? = raw.filterIsInstance<T>().lastOrNull()
 }

--- a/kudos-ms/kudos-ms-sys/kudos-ms-sys-core/test-src/io/kudos/ms/sys/core/resource/event/SysResourceEventPublishingTest.kt
+++ b/kudos-ms/kudos-ms-sys/kudos-ms-sys-core/test-src/io/kudos/ms/sys/core/resource/event/SysResourceEventPublishingTest.kt
@@ -61,5 +61,5 @@ open class ResourceEventCaptor {
         raw.clear()
     }
 
-    inline fun <reified T> lastOf(): T? = raw.filterIsInstance<T>().lastOrNull()
+    final inline fun <reified T> lastOf(): T? = raw.filterIsInstance<T>().lastOrNull()
 }

--- a/kudos-ms/kudos-ms-sys/kudos-ms-sys-core/test-src/io/kudos/ms/sys/core/tenant/event/SysTenantEventPublishingTest.kt
+++ b/kudos-ms/kudos-ms-sys/kudos-ms-sys-core/test-src/io/kudos/ms/sys/core/tenant/event/SysTenantEventPublishingTest.kt
@@ -71,5 +71,5 @@ open class TenantEventCaptor {
         raw.clear()
     }
 
-    inline fun <reified T> lastOf(): T? = raw.filterIsInstance<T>().lastOrNull()
+    final inline fun <reified T> lastOf(): T? = raw.filterIsInstance<T>().lastOrNull()
 }


### PR DESCRIPTION
- Bump Kotlin 2.3.21 -> 2.4.0 in version catalog (drives kotlin-gradle-plugin, allopen, reflect, test, serialization plugin).
- Fix 2.4.0 hard error "inline modifier on virtual members is prohibited": mark allopen-opened @Component test recorders' `inline reified lastOf()` as `final` (4 SysXxxEventPublishingTest files).
- Migrate UUID generation from java.util.UUID to the now-stable kotlin.uuid.Uuid in RandomStringKit (uuid()/uuidWithoutDelimiter(), dropping a regex), then converge scattered inline UUID call sites onto RandomStringKit across cache / web / feign / websocket / jwt / context modules.
- Keep java.util.UUID in KtormSqlType / JdbcTypeToKotlinType: those are Kotlin<->JDBC/SQL type-mapping keys and must stay java.util.UUID.