### PR TITLE
feat(auth): roleNamesByResourceIds aggregator for permission console

### DIFF
--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-api-admin/src/io/kudos/ms/auth/api/admin/controller/resource/AuthResourcePermissionAdminController.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-api-admin/src/io/kudos/ms/auth/api/admin/controller/resource/AuthResourcePermissionAdminController.kt
@@ -1,0 +1,40 @@
+package io.kudos.ms.auth.api.admin.controller.resource
+
+import io.kudos.ms.auth.core.role.service.iservice.IAuthRoleService
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+
+/**
+ * Resource / menu permission administration controller.
+ *
+ * Base URL: `/api/admin/auth/resourcepermission`
+ *
+ * The resource and menu data themselves (rows, tree, pagination) are owned by kudos-ms-sys and read
+ * through its `/api/admin/sys/resource/...` endpoints. This controller only supplies the role↔resource
+ * projection the permission console overlays on those rows: given the ids of the resources currently
+ * on screen, the names of the roles granted each one.
+ *
+ *   POST /roleNamesByResourceIds   body=[resourceIds]   → Map<resourceId, List<roleName>>
+ *
+ * @author K
+ * @author AI: Claude
+ * @since 1.0.0
+ */
+@RestController
+@RequestMapping("/api/admin/auth/resourcepermission")
+class AuthResourcePermissionAdminController(
+    private val authRoleService: IAuthRoleService,
+) {
+
+    /**
+     * Batch-resolve the granting roles for a page of resources. Resources with no roles are omitted
+     * from the response. Body is a JSON array of resource ids.
+     */
+    @PostMapping("/roleNamesByResourceIds")
+    fun roleNamesByResourceIds(@RequestBody resourceIds: List<String>): Map<String, List<String>> =
+        authRoleService.getRoleNamesByResourceIds(resourceIds)
+
+}

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/src/io/kudos/ms/auth/core/role/service/impl/AuthRoleService.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/src/io/kudos/ms/auth/core/role/service/impl/AuthRoleService.kt
@@ -317,6 +317,22 @@ open class AuthRoleService(
     }
 
     @Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+    override fun getRoleNamesByResourceIds(resourceIds: Collection<String>): Map<String, List<String>> {
+        if (resourceIds.isEmpty()) return emptyMap()
+        // resourceId -> role ids granted that resource (one cache hit per resource).
+        val roleIdsByResource: Map<String, Set<String>> = resourceIds.toSet().associateWith { resId ->
+            authRoleResourceService.getRoleIdsByResourceId(resId)
+        }
+        // Resolve every referenced role's metadata once, then map ids -> names.
+        val allRoleIds: Set<String> = roleIdsByResource.values.asSequence().flatten().toSet()
+        val rolesMap: Map<String, AuthRoleCacheEntry> =
+            if (allRoleIds.isEmpty()) emptyMap() else authRoleHashCache.getRolesByIds(allRoleIds)
+        return roleIdsByResource
+            .mapValues { (_, rids) -> rids.mapNotNull { rolesMap[it]?.name }.distinct().sorted() }
+            .filterValues { it.isNotEmpty() }
+    }
+
+    @Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
     override fun getDeleteImpact(roleIds: Collection<String>): RoleDeleteImpactVo {
         if (roleIds.isEmpty()) return RoleDeleteImpactVo.zero()
         // Union over all roles. Sets de-duplicate so a user/group bound to multiple roles in the

--- a/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/src/io/kudos/ms/auth/core/role/service/iservice/IAuthRoleService.kt
+++ b/kudos-ms/kudos-ms-auth/kudos-ms-auth-core/src/io/kudos/ms/auth/core/role/service/iservice/IAuthRoleService.kt
@@ -210,6 +210,19 @@ interface IAuthRoleService : IBaseCrudService<String, AuthRole> {
     fun getEffectivePermissions(userId: String): EffectivePermissionsVo
 
     /**
+     * Batch aggregator for the resource / menu permission console: for each supplied resource id,
+     * the distinct, alphabetically sorted names of the roles that have been granted that resource.
+     *
+     * Resources with no granting role are omitted from the result map (the contract is "which roles
+     * can reach these resources", not "echo back every id"). Replaces the page's per-row fan-out over
+     * `listRoleIdsByResource` + role-name lookups with a single round-trip.
+     *
+     * @param resourceIds resource ids to resolve; empty input yields an empty map.
+     * @return resourceId -> sorted distinct role names, excluding resources with no roles.
+     */
+    fun getRoleNamesByResourceIds(resourceIds: Collection<String>): Map<String, List<String>>
+
+    /**
      * Aggregate impact summary for deleting a batch of roles: counts of distinct users and
      * groups currently bound to any role in [roleIds]. Used by the admin UI's pre-delete
      * confirmation so operators see the blast radius without spawning 2N GETs.


### PR DESCRIPTION
Add IAuthRoleService.getRoleNamesByResourceIds(ids) -> Map<resourceId, List<roleName>> (impl in AuthRoleService reuses authRoleResourceService + authRoleHashCache) and expose it via a new AuthResourcePermissionAdminController at POST /api/admin/auth/resourcepermission/roleNamesByResourceIds.

Backs the rewritten resource/menu permission pages in kudos-console-ui: sys owns resource/menu data + pagination, auth owns the role-resource projection.